### PR TITLE
spec: redesign Workflow as directed graph, add embedding_text field, …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 - **§27.7 Consensus Grain Usage for Action Definition Validation** — documented usage pattern for recording multi-source agreement on Action definition grains via the Consensus grain type.
 - **Updated §27.1 tool definition example** to include `output_schema` field.
 - **Updated Anthropic API alignment table** in §27.1 to note `output_schema` has no Anthropic equivalent.
-- **`CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md` — Context Assembly Language v1.0** bundled into this repository as part of OMS v1.3. CAL is a non-destructive, deterministic, LLM-native language for assembling agent context from OMS stores. **SML (Semantic Markup Language)** is now its own standalone specification at `SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md`. OMS spec gains §1.5 (Companion Specifications) and §28.8 (CAL/SML store operation mapping).
+- **`CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md` — Context Assembly Language v1.0** bundled into this repository as part of OMS v1.3. CAL is a non-destructive, deterministic, LLM-native language for assembling agent context from OMS stores. **SML (Semantic Markup Language)** is now its own standalone specification at `SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md`. OMS spec gains §1.5 (Companion Specifications) and §28.9 (CAL/SML store operation mapping).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`embedding_text` common field (§6.1)** — optional `string` (compact key: `et`) providing source text for vector embedding and full-text indexing. When present, implementations SHOULD use this value instead of the grain's default per-type text representation. Enables document-derived grains to preserve source paragraph context for retrieval while maintaining structured subject/relation/object triples. Benchmarked at +29.4pp Recall@10 improvement on a 28-grain refund policy dataset. See `proposals/embedding-text-field.md`.
+- **Appendix C** — added `"et": "embedding_text"` to core field compaction table.
+- **Workflow grain type redesigned as directed graph (§8.4)** — Workflow grains now model directed graphs instead of flat step lists. New fields: `nodes` (array[string]), `edges` (array[map] with `src`, `dst`, `cond`, `max_cycles`), `bindings` (map[string→string] mapping node IDs to Action definition grain hashes), `retries` (map[string→int]). Supports sequential, parallel fork/join, conditional branching, and bounded cycles. Three-tier node-to-Action resolution (bound → named → abstract). Replaces `steps` array.
+- **Workflow structural semantics (§8.4)** — node types inferred from graph topology: fork (multiple outgoing edges), AND-join (multiple incoming edges), decision point (conditional edges), terminal (no outgoing edges). Entry point is first element of `nodes`.
+- **`mg:has_graph` relation** — replaces `mg:requires_steps` for Workflow grains. Reflects the directed graph model.
+
+### Changed
+
+- **Workflow grain description** — "Learned action sequence — procedural memory" → "Directed graph of procedural steps — plans, pipelines, processes".
+- **Workflow fields** — `steps` (array[string]) and `trigger` (string) replaced by `nodes`, `edges`, `bindings`, `retries`, and optional `trigger`. Edge schema uses nested `src`/`dst`/`cond`/`max_cycles` fields with compaction keys.
+- **`mg:requires_steps`** renamed to **`mg:has_graph`** in the `mg:` standard relation vocabulary.
+
+### CAL 1.1 — Added
+
+- **Multi-format output (§10.1.1)** — `FORMAT` and `AS` clauses now accept bracketed format lists (`FORMAT [markdown, json]`) with optional aliases (`FORMAT [json AS structured, markdown AS report]`). Single query execution produces multiple renderings. New multi-format response shape (`"formats"` object, §14.2.1). Maximum 5 formats per list. New error codes: `CAL-E110` (too many formats), `CAL-E113` (duplicate format key).
+- **Workflow graph syntax for ADD/SUPERSEDE (§8.8.1)** — dedicated graph syntax for workflow grains using `->` (sequential edges), `()` (parallel fork/join), `WHEN` (conditional edges), `* N` (retry bounds), `BIND` (node-to-Action mapping), and `ON` (trigger clause). Full graph replacement on SUPERSEDE.
+- **`BECAUSE` alias** — accepted as synonym for `REASON` in ADD, SUPERSEDE, and workflow statements.
+
+### CAL 1.1 — Changed
+
+- **Pipeline operators removed** — bare pipe syntax (`| ORDER BY`, `| LIMIT`, `| COUNT`, etc.) replaced by direct clause syntax (`ORDER BY`, `LIMIT`, `COUNT`). All examples and grammar productions updated. Backward-compatible at the semantic level.
+- **Workflow query fields** — `steps` field replaced by `node` and `binding` for grain-type-specific querying.
+- **Workflow content projection** — `nodes` joined with `->` arrow syntax replaces numbered `steps` list in SML/template output.
+- **`GrainTypeNotAddable` (CAL-E051)** — Workflow added to the set of addable grain types (Belief, Observation, Goal, Workflow).
+
+---
+
 ## [1.3] — 2026-03-03
 
 ### Added
@@ -59,7 +90,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 - **New `recall_priority` field** — storage tier hint: `"hot"`, `"warm"`, `"cold"`
 - **New `invalidation_policy` modes:** `"hold"` (litigation hold — blocks all erasure until explicitly lifted) and `"consent_cascade"` (auto-erasure within ≤ 30 days when linked Consent grain is revoked)
 - **`source_type` new values:** `"established_knowledge"` (physical constants, scientific laws) and `"axiomatic"` (mathematical axioms, tautologies)
-- **`mg:` standard relation vocabulary** — 21 standard relations: `mg:perceives`, `mg:knows`, `mg:said`, `mg:did`, `mg:infers`, `mg:agrees_with`, `mg:state_at`, `mg:requires_steps`, `mg:intends`, `mg:permits`, `mg:revokes`, `mg:prohibits`, `mg:requires`, `mg:prefers`, `mg:avoids`, `mg:delegates_to`, `mg:owned_by`, `mg:has_capability`, `mg:handed_off_to`, `mg:depends_on`, `mg:assigned_to`
+- **`mg:` standard relation vocabulary** — 21 standard relations: `mg:perceives`, `mg:knows`, `mg:said`, `mg:did`, `mg:infers`, `mg:agrees_with`, `mg:state_at`, `mg:has_graph`, `mg:intends`, `mg:permits`, `mg:revokes`, `mg:prohibits`, `mg:requires`, `mg:prefers`, `mg:avoids`, `mg:delegates_to`, `mg:owned_by`, `mg:has_capability`, `mg:handed_off_to`, `mg:depends_on`, `mg:assigned_to`
 - **HIPAA PHI tag normalization** — 18 normative `phi:` tag values per 45 CFR §164.514(b) Safe Harbor
 - **External citation schema** in `content_refs` — structured citations for doi/arxiv/pmid/isbn/rrid/clinicaltrials/url with `citation_role`
 - **§12.5 Agent Ownership and Legal Entity** — Belief grain pattern with `mg:owned_by` relation

--- a/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
+++ b/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
@@ -1,6 +1,6 @@
 # CAL (Context Assembly Language) Specification v1.0
 
-**Status:** Standards Track | **Date:** 2026-03-03 | **Version:** 1.0 | **Classification:** Experimental
+**Status:** Standards Track | **Date:** 2026-03-05 | **Version:** 1.1 | **Classification:** Experimental
 **Part of:** [Open Memory Specification (OMS) v1.3](./SPECIFICATION.md)
 ---
 
@@ -235,7 +235,7 @@ recall_priority, epistemic_status
 ```
 role, session_id, parent_message_id, model_id, content,
 context, plan,
-trigger, steps,
+trigger, nodes, edges, bindings, retries,
 tool_name, action_phase, is_error, tool_call_id,
 observer_id, observer_type,
 goal_state, assigned_agent, deadline, depends_on,
@@ -342,7 +342,9 @@ let_ref         = "$" , identifier ;
 
 budget_clause   = "BUDGET" , positive_integer , ( "tokens" | "grains" ) ;
 priority_clause = "PRIORITY" , label , { ">" , label } ;
-format_clause   = "FORMAT" , format_spec ;
+format_clause   = "FORMAT" , format_value ;
+format_value    = format_spec | "[" , aliased_format , { "," , aliased_format } , "]" ;
+aliased_format  = format_spec , [ "AS" , identifier ] ;
 format_spec     = format_type
                 | preset_name
                 | "TEMPLATE" , template_name
@@ -360,7 +362,7 @@ since_clause    = "SINCE" , string_literal ;
 like_clause     = "LIKE" , string_literal ;
 between_clause  = "BETWEEN" , value , "AND" , value ;
 contradictions_clause = "CONTRADICTIONS" ;
-as_clause       = "AS" , format_type ;
+as_clause       = "AS" , ( format_spec | "[" , aliased_format , { "," , aliased_format } , "]" ) ;
 
 thread_clause   = "THREAD" , thread_target ;
 thread_target   = string_literal | "FROM" , hash_literal ;
@@ -407,7 +409,7 @@ grain_field_name = event_field | state_field | workflow_field
 
 event_field     = "role" | "session_id" | "parent_message_id" | "model_id" | "content" ;
 state_field     = "context" | "plan" ;
-workflow_field  = "trigger" | "steps" ;
+workflow_field  = "trigger" | "node" | "binding" ;
 action_field    = "tool_name" | "action_phase" | "is_error" | "tool_call_id" ;
 observation_field = "observer_id" | "observer_type" ;
 goal_field      = "goal_state" | "assigned_agent" | "deadline" | "depends_on" ;
@@ -442,7 +444,7 @@ consistency_level = "eventual" | "bounded" , "(" , number , ")" | "linearizable"
 disclosure_level = "summary" | "headlines" | "full" ;
 extension_option = "x_" , identifier , [ "(" , value_list , ")" ] ;
 
-pipeline        = { "|" , pipe_stage } ;
+pipeline        = { pipe_stage } ;
 pipe_stage      = select_stage | order_stage | limit_stage | offset_stage
                 | count_stage | first_stage | subjects_stage | objects_stage
                 | hashes_stage | group_stage | project_stage ;
@@ -463,8 +465,10 @@ project_field   = field_name | grain_field_name | domain_field ;
 
 (* --- Tier 1: Evolve --- *)
 
-add_stmt        = "ADD" , grain_type_singular , add_clause , { add_clause } , reason_clause ;
-supersede_stmt  = "SUPERSEDE" , ( hash_literal | parameter ) , set_clause , { set_clause } , reason_clause ;
+add_stmt        = "ADD" , grain_type_singular , add_clause , { add_clause } , reason_clause
+                | workflow_add_stmt ;
+supersede_stmt  = "SUPERSEDE" , ( hash_literal | parameter ) , set_clause , { set_clause } , reason_clause
+                | workflow_supersede_stmt ;
 revert_stmt     = "REVERT" , ( hash_literal | parameter ) , reason_clause ;
 
 add_clause      = "SET" , ( add_field | grain_add_field ) , "=" , value ;
@@ -476,7 +480,24 @@ observation_add_field = "observer_id" | "observer_type" ;
 
 set_clause      = "SET" , evolve_field , "=" , value ;
 evolve_field    = "object" | "confidence" | "importance" | "tags" ;
-reason_clause   = "REASON" , string_literal ;
+reason_clause   = ( "REASON" | "BECAUSE" ) , string_literal ;
+
+(* --- Workflow graph syntax --- *)
+
+workflow_add_stmt       = "ADD" , "workflow" , string_literal ,
+                          [ on_clause ] , graph_line , { graph_line } ,
+                          { bind_clause } , reason_clause ;
+workflow_supersede_stmt = "SUPERSEDE" , hash_literal ,
+                          [ on_clause ] , graph_line , { graph_line } ,
+                          { bind_clause } , reason_clause ;
+on_clause               = "ON" , string_literal ;
+bind_clause             = "BIND" , node_name , "=" , hash_literal ;
+
+graph_line              = node_or_group , { "->" , node_or_group , [ when_mod ] , [ repeat_mod ] } ;
+node_or_group           = node_name | "(" , node_name , { "," , node_name } , ")" ;
+node_name               = identifier | string_literal ;
+when_mod                = "WHEN" , string_literal ;
+repeat_mod              = "*" , positive_integer ;
 
 (* --- Template definitions --- *)
 
@@ -627,8 +648,9 @@ All Belief fields are in the common set (`subject`, `relation`, `object`, `confi
 
 | Field | Type | Operators | Notes |
 |-------|------|-----------|-------|
-| `trigger` | String | `=`, `!=` | Trigger condition (e.g., `"on:user_message"`) |
-| `steps` | String | `=` | Semantic search on workflow steps |
+| `trigger` | String | `=`, `!=` | Trigger condition (e.g., `"on:merge_to_main"`) |
+| `node` | String | `=` | Match workflows containing a specific node |
+| `binding` | String | `=` | Match workflows binding to a specific Action grain hash |
 
 #### Action (0x05) -- `RECALL actions`
 
@@ -740,7 +762,7 @@ OMS defines a standard `mg:` relation vocabulary. CAL provides first-class suppo
 | `mg:infers` | Knowledge | Agent | Conclusion | Inference result |
 | `mg:agrees_with` | Consensus | Agent | Proposition | Agreement record |
 | `mg:state_at` | Observation | Agent | State snapshot | Point-in-time state |
-| `mg:requires_steps` | Workflow | Process | Step sequence | Workflow definition |
+| `mg:has_graph` | Workflow | Process | Graph of steps | Workflow definition |
 | `mg:intends` | Lifecycle | Entity | Objective | Goal declaration |
 | `mg:permits` | Permission | Grantor DID | Action/scope | Permission grant |
 | `mg:revokes` | Permission | Grantor DID | Action/scope | Permission withdrawal |
@@ -774,7 +796,7 @@ CAL defines **relation category shortcuts** as syntactic sugar for common multi-
 ```sql
 -- All preference-related beliefs about alice
 RECALL beliefs WHERE subject = "alice" AND relation IS PREFERENCE
-  | ORDER BY confidence DESC
+  ORDER BY confidence DESC
 
 -- All permission records for a DID
 RECALL WHERE subject = "did:key:z6Mk..." AND relation IS PERMISSION
@@ -812,8 +834,8 @@ Retrieves grains matching the given filters. Returns results using the OMS Stand
 ```sql
 RECALL beliefs WHERE subject = "alice" AND relation = "prefers"
   WITH contradiction_detection
-  | ORDER BY confidence DESC
-  | LIMIT 10
+  ORDER BY confidence DESC
+  LIMIT 10
 ```
 
 RECALL supports semantic shortcuts (ABOUT, RECENT, SINCE, LIKE, MY, CONTRADICTIONS -- see section 9), grain-type-specific fields (section 6), thread shorthand (section 8.1.1), and per-query format control via AS.
@@ -821,7 +843,7 @@ RECALL supports semantic shortcuts (ABOUT, RECENT, SINCE, LIKE, MY, CONTRADICTIO
 ```sql
 -- With grain-type-specific fields
 RECALL actions WHERE tool_name = "get_weather" AND is_error = false
-  | ORDER BY time DESC | LIMIT 20
+  ORDER BY time DESC LIMIT 20
 
 -- With domain profile fields
 RECALL beliefs WHERE tags INCLUDE ["profile:healthcare"]
@@ -835,7 +857,7 @@ The `THREAD` keyword provides concise syntax for conversation retrieval:
 ```sql
 -- Full conversation in a session
 RECALL events THREAD "sess-123"
--- Expands to: RECALL events WHERE session_id = "sess-123" | ORDER BY time ASC
+-- Expands to: RECALL events WHERE session_id = "sess-123" ORDER BY time ASC
 
 -- Full thread containing a specific message
 RECALL events THREAD FROM sha256:a1b2c3d4...
@@ -854,7 +876,7 @@ CAL/1 ASSEMBLE user_context
     events:   (RECALL events WHERE user_id = "alice" RECENT 5),
     history:  (RECALL beliefs ABOUT "alice"
                 WHERE relation = "prefers" WITH superseded
-                | ORDER BY time DESC | LIMIT 3)
+                ORDER BY time DESC LIMIT 3)
   BUDGET 2000 tokens
   PRIORITY beliefs > goals > events > history
   FORMAT markdown
@@ -971,9 +993,74 @@ ADD belief
   REASON "user stated preference during onboarding conversation"
 ```
 
-**Addable grain types:** Belief, Observation, Goal. Events, Actions, States, and other types represent system-generated records and are not user-creatable.
+**Addable grain types:** Belief, Observation, Goal, Workflow. Events, Actions, States, and other types represent system-generated records and are not user-creatable.
 
-**Required SET fields:** `subject`, `relation`, `object`. `REASON` is mandatory.
+**Required SET fields (Belief):** `subject`, `relation`, `object`. `REASON` is mandatory.
+
+#### 8.8.1 ADD Workflow (Graph Syntax)
+
+Workflows use a dedicated graph syntax instead of SET clauses. The graph is expressed with arrows (`->`), parallel groups (`()`), conditions (`WHEN`), and repeat bounds (`* N`).
+
+```sql
+-- Simple linear workflow
+ADD workflow "nightly backup"
+  ON "cron 0 2 * * *"
+  snapshot -> compress -> upload
+  REASON "automate database backups"
+
+-- Parallel fork/join
+ADD workflow "code review"
+  ON "PR opened"
+  lint -> (security_review, compliance_review) -> evaluate
+  REASON "parallel review gates"
+
+-- Conditional branching
+ADD workflow "release gate"
+  ON "review complete"
+  evaluate -> implement WHEN "approved"
+  evaluate -> reject WHEN "rejected"
+  REASON "approval-based routing"
+
+-- Retry on failure
+ADD workflow "resilient deploy"
+  ON "release"
+  build -> deploy * 3 -> notify
+  REASON "retry deploy up to 3 times"
+
+-- Full pipeline with bindings
+ADD workflow "release pipeline"
+  ON "merge to main"
+  build -> (unit_test, lint) -> integration_test
+  integration_test -> stage_deploy * 3
+  stage_deploy -> approval
+  approval -> prod_deploy WHEN "approved"
+  approval -> rollback WHEN "rejected"
+  prod_deploy -> notify
+  rollback -> notify
+  BIND build = sha256:def111...
+  BIND stage_deploy = sha256:def333...
+  BIND prod_deploy = sha256:def444...
+  REASON "standard release process"
+```
+
+**Clause order (fixed):** name → ON → graph lines → BIND → REASON
+
+**Graph operators:**
+
+| Operator | Meaning | Example |
+|----------|---------|---------|
+| `->` | Sequential edge | `build -> test` |
+| `(a, b)` | Parallel fork/join | `(lint, test) -> merge` |
+| `WHEN "cond"` | Conditional edge | `-> deploy WHEN "approved"` |
+| `* N` | Repeat up to N times on failure | `deploy * 3` |
+
+**Operator precedence:** `* N` (highest) > `WHEN` > `->` (lowest).
+
+**Structural inference:** Node types are inferred from graph topology — a node with multiple unconditional outgoing edges is a fork, a node receiving multiple edges is an AND-join, a node with `WHEN` edges is a decision point.
+
+**BIND clause:** Maps a node name to an Action definition grain hash (`action_phase: "definition"`). The executor fetches the definition to discover `tool_name`, `input_schema`, etc. Unbound nodes are resolved by name convention or treated as abstract steps.
+
+**Node names:** Bare identifiers (`build`, `unit_test`) or quoted strings (`"send welcome email"`). Reserved words (`ADD`, `workflow`, `ON`, `WHEN`, `BIND`, `REASON`, `BECAUSE`) must be quoted.
 
 ### 8.9 SUPERSEDE (Tier 1)
 
@@ -986,7 +1073,21 @@ SUPERSEDE sha256:target_hash
   REASON "user explicitly changed preference"
 ```
 
-Only Belief grains can be superseded via CAL. At least one `SET` clause and `REASON` are required.
+**Belief supersession:** At least one `SET` clause and `REASON` are required.
+
+**Workflow supersession:** Uses graph syntax (full graph replacement):
+
+```sql
+SUPERSEDE sha256:abc123...
+  ON "merge to main"
+  build -> (unit_test, lint, security_scan) -> integration_test
+  integration_test -> canary_deploy * 3
+  canary_deploy -> approval
+  approval -> prod_deploy WHEN "approved"
+  approval -> rollback WHEN "rejected"
+  BIND security_scan = sha256:def888...
+  REASON "added security scan, replaced stage with canary"
+```
 
 ### 8.10 REVERT (Tier 1)
 
@@ -1017,7 +1118,7 @@ LET bindings name intermediate RECALL results that can be referenced by `$name` 
 ```sql
 CAL/1
 LET $team_members = RECALL beliefs
-  WHERE relation = "member_of" AND object = "team-alpha" | SUBJECTS;
+  WHERE relation = "member_of" AND object = "team-alpha" SUBJECTS;
 
 LET $team_prefs = RECALL beliefs
   WHERE subject IN ($team_members) AND relation = "prefers";
@@ -1071,7 +1172,7 @@ RECALL beliefs ABOUT "alice"
 
 ```sql
 RECALL events ABOUT "alice" RECENT 5
--- Desugars to: RECALL events WHERE subject = "alice" | ORDER BY time DESC | LIMIT 5
+-- Desugars to: RECALL events WHERE subject = "alice" ORDER BY time DESC LIMIT 5
 ```
 
 ### 9.3 SINCE
@@ -1140,6 +1241,45 @@ RECALL events BETWEEN 1709251200 AND 1709337600
 | `triples` | Triples | Subject-relation-object triples |
 | `toon` | TOON | Token-Oriented Object Notation — CSV-tabular for uniform grain arrays; ~40% fewer tokens vs JSON. Optimised for large RECALL result sets and budget-constrained ASSEMBLE. See Section 10.9. |
 
+### 10.1.1 Multi-Format Output
+
+The `FORMAT` and `AS` clauses accept either a single format name or a bracketed list of format names. When a list is provided, the implementation executes the query **once** and renders the result set into **each** requested format, returning all renderings in a single response.
+
+**Single format** (existing behavior):
+
+```
+CAL/1 RECALL beliefs ABOUT "alice" FORMAT markdown
+CAL/1 RECALL beliefs ABOUT "alice" AS json
+```
+
+**Multi-format:**
+
+```
+CAL/1 RECALL beliefs ABOUT "alice" FORMAT [markdown, json]
+CAL/1 RECALL beliefs ABOUT "alice" AS [markdown, json]
+```
+
+**Multi-format with aliases:**
+
+Each format in a bracketed list MAY include an `AS <identifier>` alias. When present, the alias becomes the key in the multi-format response object (Section 14.2.1) instead of the canonical format name. Aliases are particularly useful when the list contains multiple templates (which would otherwise all share the key `"template"`) or when the client wants semantically meaningful keys.
+
+```
+CAL/1 RECALL beliefs FORMAT [json AS customers, markdown AS report]
+CAL/1 RECALL beliefs FORMAT [json AS structured, TEMPLATE "{{subject}}: {{object}}" AS oneliner]
+CAL/1 RECALL beliefs FORMAT [TEMPLATE "{{subject}}" AS names, TEMPLATE "{{object}}" AS values]
+```
+
+**Rules:**
+
+1. The query executes once. All format renderings share the same result set.
+2. When a single format is specified, the response uses the `"format"` / `"content"` fields (Section 14.2). When a format list is specified, the response uses a `"formats"` object keyed by format name or alias (Section 14.2.1).
+3. `FORMAT [json]` (single-element list) uses the multi-format response shape (`"formats"` object with one key), not the single-format shape.
+4. `FORMAT []` (empty list) is a parse error.
+5. Duplicate format names in the list (without aliases) are deduplicated silently; each format is rendered at most once.
+6. Maximum 5 formats per list. Exceeding this limit produces a `CAL-E110` error.
+7. When aliases are used, the effective key (alias or canonical name) MUST be unique across the list. Duplicate keys where at least one is an explicit alias produce a `CAL-E113` error.
+8. Aliases follow identifier syntax (`[a-z][a-z0-9_]*`). Aliases are only supported in bracketed format lists, not in bare comma-separated lists.
+
 ### 10.2 Custom Templates (Mustache-subset)
 
 CAL templates use a strict subset of Mustache:
@@ -1174,7 +1314,7 @@ Each grain type defines a **content rule** (what becomes the text content of the
 | **Observation** | `object` (what was observed) | `observer`? |
 | **Reasoning** | `conclusion` | `type`? |
 | **State** | `plan` (summary) | `context`? |
-| **Workflow** | `steps` (joined as readable text) | `trigger`? |
+| **Workflow** | `nodes` (joined as readable text) | `trigger`? |
 | **Consensus** | `object` (the agreed claim) | `threshold`?, `count`? |
 | **Consent** | `purpose` | `action`, `grantor`, `grantee` |
 
@@ -1364,7 +1504,7 @@ FORMAT TEMPLATE {
 
   <state context="q1_review_prep">outlining slides: 1. headline metrics  2. incident retrospective  3. velocity trend  4. Q2 goals</state>
 
-  <workflow trigger="review_prep_requested">1. retrieve Q1 metrics  2. identify narrative arc  3. draft slide outline  4. populate data  5. send for review by 2026-03-14</workflow>
+  <workflow trigger="review_prep_requested">retrieve_metrics -> identify_narrative -> draft_outline -> populate_data -> send_for_review</workflow>
 
   <consensus threshold="3" count="4">Q1 deployment frequency improved 18% over Q4 2025</consensus>
 
@@ -1557,8 +1697,8 @@ The `PROJECT` clause (Section 10.3.5) works with TOON. The projected fields beco
 
 ```sql
 CAL/1 RECALL observations WHERE tags INCLUDE ["profile:healthcare"]
-  | PROJECT content(object), attr(hc:patient_id, hc:encounter_id)
-  | LIMIT 10 AS toon
+  PROJECT content(object), attr(hc:patient_id, hc:encounter_id)
+  LIMIT 10 AS toon
 ```
 
 Output (root array — RECALL result):
@@ -1736,7 +1876,7 @@ RECALL beliefs WHERE tags INCLUDE ["profile:healthcare"]
   AND hc:patient_id = "P-12345"
   AND hc:condition_code IN ("J06.9", "J20.9")
   AND relation = "mg:knows"
-  | ORDER BY time DESC | LIMIT 20
+  ORDER BY time DESC LIMIT 20
 ```
 
 The parser SHOULD emit warning `CAL-W002` if a domain field is used without the corresponding `profile:` tag.
@@ -1825,6 +1965,45 @@ A formatted representation for direct insertion into LLM context windows. The co
 
 The machine envelope (Section 14.1) carries hashes, namespaces, full timestamps, and other storage metadata. These MUST NOT appear in the LLM content layer.
 
+#### 14.2.1 Multi-Format Response
+
+When the query specifies a format list (`FORMAT [markdown, json]`), the response replaces the single `"format"` / `"content"` fields with a `"formats"` object keyed by format name (or alias, if provided). Each value is the rendered text for that format.
+
+```json
+{
+  "_cal": {
+    "version": "1.0",
+    "statement_type": "recall",
+    "query_hash": "sha256:...",
+    "duration_ms": 38
+  },
+  "formats": {
+    "markdown": "## Beliefs\n- alice prefers dark mode (confidence: 0.92)\n",
+    "json": [
+      {"subject": "alice", "relation": "prefers", "object": "dark mode", "confidence": 0.92}
+    ]
+  },
+  "grain_count": 1,
+  "total": 1
+}
+```
+
+**With aliases** (`FORMAT [json AS structured, TEMPLATE "{{subject}}: {{object}}" AS oneliner]`):
+
+```json
+{
+  "_cal": { "version": "1.0", "statement_type": "recall", "query_hash": "sha256:...", "duration_ms": 42 },
+  "formats": {
+    "structured": [{"subject": "alice", "relation": "prefers", "object": "dark mode"}],
+    "oneliner": "alice: dark mode\n"
+  },
+  "grain_count": 1,
+  "total": 1
+}
+```
+
+**Discriminator:** Clients distinguish single-format from multi-format responses by checking for `"format"` (string) vs `"formats"` (object). Exactly one of the two keys is present when a FORMAT clause was specified. When aliases are used, the `"formats"` keys are the alias identifiers, not the canonical format names.
+
 ### 14.3 Progressive Disclosure
 
 | Level | Metadata Density | When Used |
@@ -1848,7 +2027,7 @@ Each grain type projects its fields into a **text content** string and **attribu
 | Observation | `object` | `<observation observer="system">alice opened incident-dashboard at 09:14 UTC</observation>` |
 | Reasoning | `conclusion` | `<reasoning type="deductive">alice is prioritising reliability given 3 P0 incidents; lead with incident reduction narrative</reasoning>` |
 | State | `plan` summary | `<state context="q1_review_prep">outlining slides: 1. headline metrics  2. incident retrospective  3. velocity trend  4. Q2 goals</state>` |
-| Workflow | `steps` joined | `<workflow trigger="review_prep_requested">1. retrieve Q1 metrics  2. identify narrative arc  3. draft slide outline  4. populate data  5. send for review by 2026-03-14</workflow>` |
+| Workflow | `nodes` joined | `<workflow trigger="review_prep_requested">retrieve_metrics -> identify_narrative -> draft_outline -> populate_data -> send_for_review</workflow>` |
 | Consensus | `object` | `<consensus threshold="3" count="4">Q1 deployment frequency improved 18% over Q4 2025</consensus>` |
 | Consent | `purpose` | `<consent action="granted" grantor="alice" grantee="agent">access engineering metrics dashboards for review preparation</consent>` |
 
@@ -1937,7 +2116,7 @@ Implementations MUST declare cross-lingual capability in `DESCRIBE capabilities`
 Default: Unicode code point order (binary sort). Locale-aware sorting requested via `WITH locale("xx")`:
 
 ```sql
-RECALL beliefs ABOUT "alice" | ORDER BY object ASC WITH locale("de")
+RECALL beliefs ABOUT "alice" ORDER BY object ASC WITH locale("de")
 ```
 
 Locale-aware sorting is optional. Implementations that do not support it MUST ignore the `locale()` option with a warning.
@@ -2109,7 +2288,7 @@ CAL queries execute through the same read path as all other interfaces. No CAL s
 
 ### 19.2 GDPR Implications
 
-- **Art. 15 (Right of Access):** CAL enables DSAR via `RECALL WHERE user_id = "alice" | COUNT`
+- **Art. 15 (Right of Access):** CAL enables DSAR via `RECALL WHERE user_id = "alice" COUNT`
 - **Art. 16 (Right to Rectification):** CAL SUPERSEDE enables correction of inaccurate personal data.
 - **Art. 17 (Right to Erasure):** Excluded at grammar level. Erasure only via implementation-specific APIs.
 - **Art. 20 (Data Portability):** CAL can serve as query interface for exports.
@@ -2243,6 +2422,7 @@ See [Appendix C](#appendix-c-error-code-registry) for the complete registry. Err
 | CAL-E075 -- CAL-E082 | Streaming | 8 |
 | CAL-E085 -- CAL-E096 | Template | 12 |
 | CAL-E100 | Version | 1 |
+| CAL-E110, CAL-E113 | Multi-Format | 2 |
 
 ### 22.3 Warning Codes
 
@@ -2298,7 +2478,7 @@ CAL introduces compliance verification checks that implementations MUST validate
 ### Level 2: Extended (SHOULD implement)
 
 Everything in Core, plus:
-- Pipeline operators (`| SELECT`, `| ORDER BY`, `| LIMIT`, `| COUNT`, `| FIRST`, `| GROUP BY`)
+- Pipeline clauses (`SELECT`, `ORDER BY`, `LIMIT`, `COUNT`, `FIRST`, `GROUP BY`)
 - Set operators (`UNION`, `INTERSECT`, `EXCEPT`)
 - Subqueries (`WHERE field IN (subquery | EXTRACTOR)`)
 - `EXPLAIN` mode
@@ -2404,7 +2584,7 @@ It can read, assemble, and evolve memories, but never delete them.
 
 ### Read operations:
   RECALL [MY] [type] [IN "ns"] [ABOUT "entity"] [WHERE conditions] [WITH options]
-    [| pipeline] [RECENT n] [SINCE "time"] [AS format]
+    [clauses] [RECENT n] [SINCE "time"] [AS format]
   ASSEMBLE name FOR "intent" FROM label:(RECALL ...), ...
     BUDGET n tokens PRIORITY l1 > l2 FORMAT markdown [STREAM]
   EXISTS sha256:hash
@@ -2439,9 +2619,9 @@ It can read, assemble, and evolve memories, but never delete them.
 
 ### Shortcuts: ABOUT, RECENT n, SINCE, LIKE, MY, CONTRADICTIONS, BETWEEN
 
-### Pipeline: | SELECT f1,f2 | ORDER BY field [ASC|DESC] | LIMIT n | COUNT
-             | FIRST | SUBJECTS | OBJECTS | HASHES | GROUP BY field
-             | PROJECT content(f1,f2), attr(f3,f4)
+### Clauses: SELECT f1,f2 ORDER BY field [ASC|DESC] LIMIT n COUNT
+             FIRST SUBJECTS OBJECTS HASHES GROUP BY field
+             PROJECT content(f1,f2), attr(f3,f4)
 
 ### Parameters: Use $name for dynamic values
 
@@ -2452,6 +2632,10 @@ It can read, assemble, and evolve memories, but never delete them.
 ### Custom templates:
   FORMAT TEMPLATE name                         -- use named template
   FORMAT TEMPLATE { ELEMENT { <{{grain.type}}>{{grain.content}}</{{grain.type}}> } }
+
+### Format aliases (in bracketed lists):
+  FORMAT [json AS customers, markdown AS report]
+  FORMAT [TEMPLATE "{{subject}}" AS names, TEMPLATE "{{object}}" AS values]
 
 ### Output formats:
   sml (default structured): flat tag-based — <belief subject="alice" confidence="0.92">prefers dark mode</belief>
@@ -2551,6 +2735,13 @@ All error codes use the `CAL-E` prefix.
 | CAL-E050 | MissingRequiredField -- ADD requires subject, relation, object |
 | CAL-E051 | GrainTypeNotAddable -- only Belief, Observation, Goal can be created |
 | CAL-E052 | AddQuotaExceeded -- too many ADD operations |
+
+### Multi-Format Errors (CAL-E110, CAL-E113)
+
+| Code | Description |
+|------|-------------|
+| CAL-E110 | Too many formats in multi-format list (maximum 5) |
+| CAL-E113 | Duplicate format key in multi-format list (alias or canonical name collision) |
 
 ### Shortcut and Grain Type Errors (CAL-E060 -- CAL-E066)
 
@@ -2699,7 +2890,8 @@ CHUNK, PAUSE, RESUME, CANCEL
 | State | `context` | String | `=`, `!=` |
 | State | `plan` | String | `=` |
 | Workflow | `trigger` | String | `=`, `!=` |
-| Workflow | `steps` | String | `=` |
+| Workflow | `node` | String | `=` |
+| Workflow | `binding` | String | `=` |
 | Action | `tool_name` | String | `=`, `!=`, `IN` |
 | Action | `action_phase` | String | `=` |
 | Action | `is_error` | Boolean | `=` |
@@ -2741,12 +2933,13 @@ CHUNK, PAUSE, RESUME, CANCEL
 
 | Version | Date | Change |
 |---------|------|--------|
+| 1.1 | 2026-03-05 | Multi-format output: FORMAT and AS clauses accept bracketed format lists (`FORMAT [markdown, json]`). Single query execution produces multiple renderings. New Section 10.1.1 (syntax and rules), Section 14.2.1 (multi-format response shape), error code CAL-E110. Backward-compatible — single-format syntax unchanged. |
 | 1.0 | 2026-03-03 | Initial CAL specification. 12-variant statement model. Tier 0 (RECALL, ASSEMBLE, SetOp, EXISTS, HISTORY, EXPLAIN, DESCRIBE, BATCH, COALESCE) + Tier 1 (ADD, SUPERSEDE, REVERT). ASSEMBLE with budget, priority, format, streaming. Semantic shortcuts (ABOUT, RECENT, SINCE, LIKE, MY, CONTRADICTIONS, BETWEEN). LET bindings. Custom FORMAT templates (Mustache-subset). Grain-type-specific queryable fields for all 10 OMS types. mg: relation vocabulary with category shortcuts. Domain profile querying. Dual wire format (text/cal + application/json+cal). Internationalization (Unicode NFC, cross-lingual search, bidi safety). Streaming protocol (SSE, NDJSON, WebSocket). THREAD shorthand. HISTORY AS OF and DIFF. Non-destructive safety model. Content Projection Model with flat semantic output (Section 10.3-10.4). PROJECT clause for custom field surfacing. Per-grain-type content projection rules with humanize() and time humanization. ELEMENT/ELEMENT_SUMMARY/SOURCE_BREAK template sections for flat semantic rendering. TOON (Token-Oriented Object Notation) format support — `toon` as a first-class FORMAT/AS preset (Section 10.9): tabular CSV rendering for uniform RECALL results, grouped-section rendering for ASSEMBLE results, per-grain-type column sets at each disclosure level, PROJECT integration, STREAM compatibility, auto-TOON budget-pressure hint (CAL-W005). |
 
 ---
 
 **Document Status:** This is the CAL (Context Assembly Language) Specification v1.0. It defines a non-destructive, deterministic, LLM-native context assembly and evolution language for OMS-compliant memory databases. CAL is part of the Open Memory Specification (OMS) v1.3 — see [SPECIFICATION.md](./SPECIFICATION.md).
 
-**Last Updated:** 2026-03-03
+**Last Updated:** 2026-03-05
 **License:** This specification is offered under the Open Web Foundation Final Specification Agreement (OWFa 1.0)
 **Copyright:** Public Domain (CC0 1.0 Universal)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Think of the `.mg` container as what JSON is to APIs or `.git` objects are to ve
 | Belief | `0x01` | Declarative knowledge: subject–relation–object triple |
 | Event | `0x02` | Timestamped occurrence: message, interaction, or utterance |
 | State | `0x03` | Agent state snapshot at a point in time |
-| Workflow | `0x04` | Multi-step procedural record |
+| Workflow | `0x04` | Directed graph of procedural steps |
 | Action | `0x05` | Tool invocation or code execution |
 | Observation | `0x06` | Sensor or cognitive input |
 | Goal | `0x07` | Intent, objective, or desired outcome |
@@ -188,7 +188,7 @@ This is the SML block injected into the LLM system prompt for the billing disput
   <event role="user"  time="5d ago">Can I switch to monthly billing?</event>
   <event role="agent" time="5d ago">Monthly billing is available — I've sent a link to make that change.</event>
 
-  <workflow trigger="billing_dispute_opened" state="open">1. verify charge  2. check renewal date  3. explain or escalate  4. offer billing-cycle change  5. close ticket</workflow>
+  <workflow trigger="billing_dispute_opened" state="open">verify_charge -> check_renewal_date -> explain_or_escalate -> offer_billing_cycle_change -> close_ticket</workflow>
 
   <action tool="get_invoice"    phase="completed">retrieved invoice INV-2026-02-28: $299 annual Professional plan renewal</action>
   <action tool="get_plan_history" phase="completed">plan enrolled 2024-03-01, renewed annually; last renewal 2026-02-28</action>

--- a/SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md
+++ b/SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md
@@ -86,7 +86,7 @@ The following example shows a single assembled context covering every grain type
 
   <state context="q1_review_prep">outlining slides: 1. headline metrics  2. incident retrospective  3. velocity trend  4. Q2 goals</state>
 
-  <workflow trigger="review_prep_requested">1. retrieve Q1 metrics  2. identify narrative arc  3. draft slide outline  4. populate data  5. send for review by 2026-03-14</workflow>
+  <workflow trigger="review_prep_requested">retrieve_metrics -> identify_narrative -> draft_outline -> populate_data -> send_for_review</workflow>
 
   <consensus threshold="3" count="4">Q1 deployment frequency improved 18% over Q4 2025</consensus>
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -200,7 +200,7 @@ Hexadecimal values are lowercase. Byte sequences are represented in hex with spa
 | 0x01 | **Belief** | Structured belief — (subject, relation, object) triple with confidence and source |
 | 0x02 | **Event** | Timestamped occurrence — message, interaction, or behavioral event |
 | 0x03 | **State** | Agent state snapshot — portable save point |
-| 0x04 | **Workflow** | Learned action sequence — procedural memory |
+| 0x04 | **Workflow** | Directed graph of procedural steps — plans, pipelines, processes |
 | 0x05 | **Action** | Tool invocation or code execution |
 | 0x06 | **Observation** | Raw sensory or cognitive input |
 | 0x07 | **Goal** | Objective with lifecycle semantics |
@@ -469,6 +469,7 @@ To minimize blob size, human-readable field names are mapped to short keys befor
 | `invalidation_initiator` | `iinit` | string | DID of the party initiating the invalidation. |
 | `retention_policy` | `rpol` | map | Minimum retention requirements: `{minimum_retention_years: int, regulation: string, deletion_requires: string}`. Distinct from `invalidation_policy` (which controls supersession). |
 | `recall_priority` | `rpri` | string | Retrieval priority hint: `"hot"`, `"warm"`, `"cold"`. Guides index layer storage tier selection. |
+| `embedding_text` | `et` | string | Source text for vector embedding and full-text indexing. When present, implementations SHOULD use this value instead of the grain's default per-type text representation for embedding generation and search indexing. Complements `embedding_refs` (which records generated vectors) by specifying the input text. Implementations MAY impose a size limit (RECOMMENDED: 8192 bytes). |
 
 > **Note — `source_type` for Observation grains:** Use `"sensor"` when `observer_type` is a physical instrument; `"agent_inferred"` when `observer_type` is a cognitive AI observer (`"llm"`, `"reflector"`, `"classifier"`, `"detector"`); `"user_explicit"` for human observers.
 
@@ -497,10 +498,22 @@ To minimize blob size, human-readable field names are mapped to short keys befor
 
 ### 6.4 Workflow-Specific Fields
 
+| Full Name | Short Key | Type | Notes |
+|-----------|-----------|------|-------|
+| `trigger` | `trigger` | string | Activation condition |
+| `nodes` | `nodes` | array[string] | Graph node IDs/labels |
+| `edges` | `edges` | array[map] | Directed edges (see §8.4 edge schema) |
+| `bindings` | `bind` | map[string→string] | Node ID → Action definition grain hash |
+| `retries` | `retries` | map[string→int] | Node ID → max repeat count |
+
+**Edge nested field compaction:**
+
 | Full Name | Short Key | Type |
 |-----------|-----------|------|
-| `steps` | `steps` | array[string] |
-| `trigger` | `trigger` | string |
+| `src` | `src` | string |
+| `dst` | `dst` | string |
+| `cond` | `cond` | string |
+| `max_cycles` | `mxc` | int |
 
 ### 6.5 Action-Specific Fields
 
@@ -729,7 +742,7 @@ The `mg:` namespace is reserved for standard semantic relations. Applications de
 | `mg:infers` | Reasoning | Derived conclusion from prior grains |
 | `mg:agrees_with` | Consensus | Multi-agent threshold agreement |
 | `mg:state_at` | State | Agent state snapshot |
-| `mg:requires_steps` | Workflow | Learned action sequence |
+| `mg:has_graph` | Workflow | Directed graph of procedural steps |
 | `mg:intends` | Goal | Agent objective |
 | `mg:permits` | Consent | User grants agent right to retain or act |
 | `mg:revokes` | Consent | User revokes prior consent |
@@ -784,15 +797,116 @@ An agent state snapshot — the portable save point at a moment in time.
 
 ### 8.4 Workflow (type = 0x04)
 
-Learned action sequence — procedural memory for recurring tasks.
+Directed graph of procedural steps — plans, pipelines, and multi-path processes.
 
 **Required fields:**
 - `type` = "workflow"
-- `steps` (non-empty array[string]) — ordered action steps
-- `trigger` (non-empty string) — condition that activates this workflow
+- `nodes` (non-empty array[string]) — graph node identifiers. Each string serves as both ID and human-readable label. Must be unique within the grain.
 - `created_at` (int64, epoch ms)
 
-**Optional fields:** All common fields.
+**Optional fields:**
+- `trigger` (string) — condition that activates this workflow
+- `edges` (array[map]) — directed edges between nodes (see edge schema below). When absent, nodes are unconnected.
+- `bindings` (map[string→string]) — maps node IDs to Action definition grain hashes (`action_phase: "definition"`). Unbound nodes are resolved by convention (tool name match) or treated as abstract steps.
+- `retries` (map[string→int]) — maps node IDs to maximum repeat count on failure. Absent means no retry.
+- All common fields.
+
+**Edge schema** (each element of `edges`):
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `src` | string | yes | ID of the source node (must exist in `nodes`) |
+| `dst` | string | yes | ID of the target node (must exist in `nodes`) |
+| `cond` | string | no | Opaque condition string; absent means unconditional |
+| `max_cycles` | int | no | Maximum traversal count for back-edges; absent means unlimited |
+
+**Structural semantics** (inferred from graph topology, not declared):
+- A node with multiple outgoing unconditional edges implies **parallel fan-out** (fork).
+- A node that is the target of multiple edges implies an **AND-join** (all predecessors must complete).
+- A node with multiple outgoing conditional edges (`cond` present) implies a **decision point**.
+- A node with no outgoing edges is a **terminal node**.
+- The **entry point** is the first element of `nodes`.
+- Back-edges (forming cycles) are permitted when bounded by `max_cycles` or `retries`.
+
+**Validation constraints:**
+- Every `src` and `dst` in `edges` MUST reference an element of `nodes`.
+- Every key in `bindings` MUST reference an element of `nodes`.
+- Every key in `retries` MUST reference an element of `nodes`.
+- Node IDs MUST be unique within `nodes`.
+- Unbounded cycles (back-edge without `max_cycles`, and no entry in `retries` for the target node) SHOULD be rejected by implementations.
+
+**Node-to-Action binding** (three-tier resolution):
+
+| Tier | Condition | Resolution |
+|------|-----------|------------|
+| Bound | Node ID present in `bindings` | Fetch the Action definition grain by hash; use its `tool_name`, `input_schema`, `output_schema` |
+| Named | No binding, but an Action definition grain exists with matching `tool_name` | Resolve by convention (implementation-defined lookup) |
+| Abstract | No binding, no matching tool | Node label is a human-readable instruction; executor (LLM or agent) interprets it |
+
+**Execution record relation:** When an agent executes a workflow node, it creates an Action grain (phase: complete or call/result) with a relation of type `mg:step_action:<node_id>` targeting the Workflow grain hash. This links execution records to the plan without modifying the immutable Workflow grain.
+
+**Example — linear pipeline:**
+
+```json
+{
+  "type": "workflow",
+  "trigger": "merge to main",
+  "nodes": ["build", "test", "deploy"],
+  "edges": [
+    {"src": "build", "dst": "test"},
+    {"src": "test", "dst": "deploy"}
+  ],
+  "created_at": 1711324800000
+}
+```
+
+**Example — parallel fork/join:**
+
+```json
+{
+  "type": "workflow",
+  "trigger": "PR opened",
+  "nodes": ["lint", "security", "compliance", "evaluate"],
+  "edges": [
+    {"src": "lint", "dst": "security"},
+    {"src": "lint", "dst": "compliance"},
+    {"src": "security", "dst": "evaluate"},
+    {"src": "compliance", "dst": "evaluate"}
+  ],
+  "created_at": 1711324800000
+}
+```
+
+**Example — conditional branching with retry and bindings:**
+
+```json
+{
+  "type": "workflow",
+  "trigger": "release requested",
+  "nodes": ["build", "unit_test", "lint", "integration_test", "stage_deploy", "approval", "prod_deploy", "rollback", "notify"],
+  "edges": [
+    {"src": "build", "dst": "unit_test"},
+    {"src": "build", "dst": "lint"},
+    {"src": "unit_test", "dst": "integration_test"},
+    {"src": "lint", "dst": "integration_test"},
+    {"src": "integration_test", "dst": "stage_deploy"},
+    {"src": "stage_deploy", "dst": "approval"},
+    {"src": "approval", "dst": "prod_deploy", "cond": "approved"},
+    {"src": "approval", "dst": "rollback", "cond": "rejected"},
+    {"src": "prod_deploy", "dst": "notify"},
+    {"src": "rollback", "dst": "notify"}
+  ],
+  "bindings": {
+    "build": "sha256:def111...",
+    "stage_deploy": "sha256:def333...",
+    "prod_deploy": "sha256:def444..."
+  },
+  "retries": {
+    "stage_deploy": 3
+  },
+  "created_at": 1711324800000
+}
+```
 
 ### 8.5 Action (type = 0x05)
 
@@ -3160,6 +3274,7 @@ footer        = 32OCTET  ; SHA-256 checksum
   "iinit": "invalidation_initiator",
   "rpol": "retention_policy",
   "rpri": "recall_priority",
+  "et": "embedding_text",
   "scope": "scope",
   "isw": "is_withdrawal",
   "basis": "basis",
@@ -3384,7 +3499,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the full version history.
 - **Belief:** Grain type 0x01 — a held claim, factual statement, or declarative knowledge about the world
 - **Event:** Grain type 0x02 — a discrete occurrence with start/end time
 - **State:** Grain type 0x03 — a persisting condition or status at a point in time
-- **Workflow:** Grain type 0x04 — a structured process or multi-step plan
+- **Workflow:** Grain type 0x04 — a directed graph of procedural steps, supporting sequential, conditional, parallel, and cyclic execution paths
 - **Action:** Grain type 0x05 — a completed tool invocation, API call, or agent action
 - **Observation:** Grain type 0x06 — a raw sensor or environmental reading without interpretation
 - **Goal:** Grain type 0x07 — a desired future state or objective

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -756,6 +756,7 @@ The `mg:` namespace is reserved for standard semantic relations. Applications de
 | `mg:handed_off_to` | Event | Session handoff event record (§28.7) |
 | `mg:depends_on` | Goal | Task dependency (distinct from `parent_goals` hierarchy) |
 | `mg:assigned_to` | Goal | Task assigned to agent for execution |
+| `mg:capable_of` | Belief | Learned skill with proficiency and strategies (§28.8 Skill Convention) |
 
 ### 8.1 Belief (type = 0x01)
 
@@ -2911,7 +2912,96 @@ When Agent A transfers control of a conversation to Agent B, the handoff is reco
 3. Agent B ingests the referenced grains, validates the delegation scope, and continues with a new `run_id` but the same `session_id`.
 4. When Agent B completes its task, it writes a Goal grain with `goal_state: "satisfied"` linked via `derived_from` to the delegation grain, and control returns to the agent specified in `return_to`.
 
-### 28.8 CAL and SML — Companion Query and Markup Languages
+### 28.8 Skill Convention
+
+Agents that learn reusable capabilities SHOULD represent them as Belief grains with `relation: "mg:capable_of"` and a structured `object` map. A skill grain captures what an agent can do, how well it can do it, and the procedural knowledge needed to transfer the capability to another agent.
+
+**Distinction from related constructs:**
+
+| Construct | Grain type | What it captures |
+|---|---|---|
+| Agent Capability (§28.5) | Belief (`mg:has_capability`) | Static identity card — what the agent *is built to do* |
+| Skill (§28.8) | Belief (`mg:capable_of`) | Learned capability — what the agent *has learned to do*, with proficiency and strategies |
+| Workflow (§8.4) | Workflow | Fixed action sequence — a single procedure, not an adaptive capability |
+
+**Convention:**
+```json
+{
+  "type": "belief",
+  "subject": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+  "relation": "mg:capable_of",
+  "object": {
+    "name": "code_review",
+    "description": "Review code changes for correctness, style, and security issues",
+    "proficiency": 0.82,
+    "strategies": [
+      {
+        "condition": "security_focused",
+        "workflow": "mg:sha256:a1b2c3...",
+        "description": "OWASP-oriented review for auth and input handling code"
+      },
+      {
+        "condition": "style_focused",
+        "workflow": "mg:sha256:d4e5f6...",
+        "description": "Linting and convention compliance review"
+      }
+    ],
+    "prerequisites": ["mg:sha256:f7e8d9..."],
+    "practice_count": 47,
+    "last_practiced_at": 1711929600000,
+    "transferable": true
+  },
+  "confidence": 0.82,
+  "source_type": "agent_inferred",
+  "namespace": "agent:skills",
+  "author_did": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+  "related_to": [
+    {"target": "mg:sha256:a1b2c3...", "type": "elaborates"},
+    {"target": "mg:sha256:d4e5f6...", "type": "elaborates"}
+  ]
+}
+```
+
+The `object` map is an open schema. Standard keys:
+
+| Key | Type | Description |
+|---|---|---|
+| `name` | string | Machine-readable skill identifier |
+| `description` | string | Human-readable summary of what the skill enables |
+| `proficiency` | float64, [0.0, 1.0] | Current mastery level. SHOULD equal the grain's top-level `confidence`. |
+| `strategies` | array[map] | Context-dependent approaches. Each entry: `{condition: string, workflow: string, description?: string}`. The `workflow` value is a content address of a Workflow grain (§8.4). |
+| `prerequisites` | array[string] | Content addresses of Skill Belief grains that must be acquired before this skill is effective |
+| `practice_count` | int | Number of successful applications (mirrors `success_count` in core fields) |
+| `last_practiced_at` | int64 | Epoch ms of most recent successful application |
+| `transferable` | bool | If `true`, another agent MAY ingest this grain and its referenced Workflow grains to acquire the skill |
+| `input_modalities` | array[string] | What the skill operates on: `"text"`, `"image"`, `"code"`, `"audio"`. Open enum. |
+| `output_modalities` | array[string] | What the skill produces |
+| `domain` | string | Domain context: `"software"`, `"research"`, `"healthcare"`, `"finance"`. Open enum. |
+
+**Namespace:** Skill Belief grains SHOULD use the `"agent:skills"` namespace to enable efficient discovery queries.
+
+**Proficiency lifecycle:**
+
+1. **Acquisition.** When an agent first learns a capability, it writes a Skill Belief grain with an initial `proficiency` (typically low). The `derived_from` field SHOULD reference the grains (Events, Actions, Reasoning) that contributed to learning.
+2. **Improvement.** Each time proficiency changes, the agent supersedes the previous Skill Belief grain with an updated `proficiency` and incremented `practice_count`. The supersession chain provides a full learning history.
+3. **Degradation.** Implementations MAY decay proficiency over time if `last_practiced_at` exceeds a threshold. This is an index-layer concern, not a grain mutation — the store writes a new superseding grain with reduced proficiency.
+
+**Skill transfer between agents:**
+
+1. Agent A queries its store: `type=belief, relation="mg:capable_of", namespace="agent:skills", transferable=true`.
+2. Agent A shares the Skill Belief grain and all Workflow grains referenced in `strategies` with Agent B (via `get_batch` on the content addresses).
+3. Agent B ingests the grains, rewrites the Skill Belief with its own `author_did`, initial `proficiency: 0.0`, and `practice_count: 0`, and sets `derived_from` to Agent A's original Skill Belief content address. The `origin_did` field preserves Agent A's DID for provenance.
+4. Agent B improves proficiency through practice, superseding the skill grain as described above.
+
+**Skill discovery:**
+
+Agents discover available skills by querying: `type=belief, relation="mg:capable_of", namespace="agent:skills", system_valid_to=null, sort=proficiency DESC`.
+
+To find agents capable of a specific skill: `type=belief, relation="mg:capable_of", object.name="code_review", system_valid_to=null`.
+
+> **Note — promotion path:** If the convention approach proves insufficient — for instance, if skill queries become performance-critical across large multi-agent deployments, or if multiple domain profiles independently require skill-specific fields at the type level — a dedicated Skill grain type (`0x0B`) with its own required fields and type byte MAY be introduced in a future OMS version, following the precedent set by Consent (§8.10).
+
+### 28.9 CAL and SML — Companion Query and Markup Languages
 
 The query conventions in this section (§28.1–§28.7) define OMS store operations and response envelopes at the structural level. The **Context Assembly Language (CAL)** ([CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md](./CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md)) is the companion specification that provides a formal, deterministic syntax for invoking these operations from an agent or LLM.
 


### PR DESCRIPTION
…evolve CAL with multi-format output and graph syntax

- Redesign Workflow grain (§8.4) from flat step list to directed graph with nodes, edges, bindings, retries; rename mg:requires_steps to mg:has_graph
- Add embedding_text common field (§6.1) for retrieval-optimized vector indexing
- CAL: multi-format output (FORMAT [markdown, json] with aliases), workflow graph syntax for ADD/SUPERSEDE, BECAUSE alias for REASON, remove bare pipe operators in favor of direct clause syntax
- Update all examples, EBNF grammar, error codes, compaction tables, SML output, and CHANGELOG

## Summary

<!-- What does this PR change? One or two sentences. -->

## Type of Change

- [ ] Editorial fix (typo, grammar, formatting)
- [ ] Clarification (improves precision of existing normative text)
- [ ] Bugfix (corrects an error in the specification)
- [ ] New feature (adds fields, types, or semantics)
- [ ] Test vector (adds or corrects test vectors)
- [ ] Other:

## Related Issue

Closes #

## Checklist

- [ ] Changes are confined to `oms-specification.md` (and test vectors if applicable)
- [ ] Normative text uses RFC 2119 keywords correctly (MUST / SHOULD / MAY in uppercase)
- [ ] New binary format changes include updated test vectors
- [ ] Backwards compatibility impact is described (or N/A for editorial changes)
- [ ] Conformance level impact is noted if applicable
- [ ] Section numbering is preserved

## Notes for Reviewers

<!-- Anything reviewers should pay special attention to. -->
