### PR TITLE
spec: rename belief→fact (0x01), action→tool (0x05) + bump OMS to v1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 
 ---
 
-## [Unreleased]
+## [1.4] — 2026-06-12
 
 ### Added
 
 - **`embedding_text` common field (§6.1)** — optional `string` (compact key: `et`) providing source text for vector embedding and full-text indexing. When present, implementations SHOULD use this value instead of the grain's default per-type text representation. Enables document-derived grains to preserve source paragraph context for retrieval while maintaining structured subject/relation/object triples. Benchmarked at +29.4pp Recall@10 improvement on a 28-grain refund policy dataset. See `proposals/embedding-text-field.md`.
 - **Appendix C** — added `"et": "embedding_text"` to core field compaction table.
-- **Workflow grain type redesigned as directed graph (§8.4)** — Workflow grains now model directed graphs instead of flat step lists. New fields: `nodes` (array[string]), `edges` (array[map] with `src`, `dst`, `cond`, `max_cycles`), `bindings` (map[string→string] mapping node IDs to Action definition grain hashes), `retries` (map[string→int]). Supports sequential, parallel fork/join, conditional branching, and bounded cycles. Three-tier node-to-Action resolution (bound → named → abstract). Replaces `steps` array.
+- **Workflow grain type redesigned as directed graph (§8.4)** — Workflow grains now model directed graphs instead of flat step lists. New fields: `nodes` (array[string]), `edges` (array[map] with `src`, `dst`, `cond`, `max_cycles`), `bindings` (map[string→string] mapping node IDs to Tool definition grain hashes), `retries` (map[string→int]). Supports sequential, parallel fork/join, conditional branching, and bounded cycles. Three-tier node-to-Tool resolution (bound → named → abstract). Replaces `steps` array.
 - **Workflow structural semantics (§8.4)** — node types inferred from graph topology: fork (multiple outgoing edges), AND-join (multiple incoming edges), decision point (conditional edges), terminal (no outgoing edges). Entry point is first element of `nodes`.
 - **`mg:has_graph` relation** — replaces `mg:requires_steps` for Workflow grains. Reflects the directed graph model.
 
@@ -37,7 +37,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 - **Pipeline operators removed** — bare pipe syntax (`| ORDER BY`, `| LIMIT`, `| COUNT`, etc.) replaced by direct clause syntax (`ORDER BY`, `LIMIT`, `COUNT`). All examples and grammar productions updated. Backward-compatible at the semantic level.
 - **Workflow query fields** — `steps` field replaced by `node` and `binding` for grain-type-specific querying.
 - **Workflow content projection** — `nodes` joined with `->` arrow syntax replaces numbered `steps` list in SML/template output.
-- **`GrainTypeNotAddable` (CAL-E051)** — Workflow added to the set of addable grain types (Belief, Observation, Goal, Workflow).
+- **`GrainTypeNotAddable` (CAL-E051)** — Workflow added to the set of addable grain types (Fact, Observation, Goal, Workflow).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 
 ### Changed
 
+- **Type renames (breaking):** `"belief"` → `"fact"` (0x01), `"action"` → `"tool"` (0x05). Byte values unchanged; existing content addresses remain valid. The `Fact` grain is the (subject, relation, object) semantic triple with confidence; the `Tool` grain records tool/action invocations and executions. Updates the grain-type table (§5), the type-specific field headings, the relation vocabulary, and the §28.8 Skill Convention `mg:capable_of` mapping (now a `Fact` grain). Legacy `"belief"`/`"action"` type strings are not accepted.
 - **Workflow grain description** — "Learned action sequence — procedural memory" → "Directed graph of procedural steps — plans, pipelines, processes".
 - **Workflow fields** — `steps` (array[string]) and `trigger` (string) replaced by `nodes`, `edges`, `bindings`, `retries`, and optional `trigger`. Edge schema uses nested `src`/`dst`/`cond`/`max_cycles` fields with compaction keys.
 - **`mg:requires_steps`** renamed to **`mg:has_graph`** in the `mg:` standard relation vocabulary.

--- a/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
+++ b/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
@@ -1,7 +1,7 @@
 # CAL (Context Assembly Language) Specification v1.0
 
 **Status:** Standards Track | **Date:** 2026-03-05 | **Version:** 1.1 | **Classification:** Experimental
-**Part of:** [Open Memory Specification (OMS) v1.3](./SPECIFICATION.md)
+**Part of:** [Open Memory Specification (OMS) v1.4](./SPECIFICATION.md)
 ---
 
 ## Table of Contents
@@ -118,7 +118,7 @@ The line between Tier 0/1 (in CAL) and Tier 2 (not in CAL) is: **can the operati
 
 ### 1.5 Relationship to OMS
 
-CAL operates on the 10 grain types defined by OMS v1.3: Belief, Event, State, Workflow, Action, Observation, Goal, Reasoning, Consensus, Consent. CAL treats this as a **closed set** -- custom types are not queryable via CAL.
+CAL operates on the 10 grain types defined by OMS v1.4: Fact, Event, State, Workflow, Tool, Observation, Goal, Reasoning, Consensus, Consent. CAL treats this as a **closed set** -- custom types are not queryable via CAL.
 
 CAL extends the Store Protocol Convention defined in OMS §28.4 ([SPECIFICATION.md](./SPECIFICATION.md)) with a formal query language. Where OMS defines the `query`, `search`, and `supersede` store operations, CAL provides a structured, deterministic syntax for invoking them safely.
 
@@ -236,7 +236,7 @@ recall_priority, epistemic_status
 role, session_id, parent_message_id, model_id, content,
 context, plan,
 trigger, nodes, edges, bindings, retries,
-tool_name, action_phase, is_error, tool_call_id,
+tool_name, tool_phase, is_error, tool_call_id,
 observer_id, observer_type,
 goal_state, assigned_agent, deadline, depends_on,
 reasoning_type, premises, conclusion,
@@ -410,7 +410,7 @@ grain_field_name = event_field | state_field | workflow_field
 event_field     = "role" | "session_id" | "parent_message_id" | "model_id" | "content" ;
 state_field     = "context" | "plan" ;
 workflow_field  = "trigger" | "node" | "binding" ;
-action_field    = "tool_name" | "action_phase" | "is_error" | "tool_call_id" ;
+action_field    = "tool_name" | "tool_phase" | "is_error" | "tool_call_id" ;
 observation_field = "observer_id" | "observer_type" ;
 goal_field      = "goal_state" | "assigned_agent" | "deadline" | "depends_on" ;
 reasoning_field = "reasoning_type" | "premises" | "conclusion" ;
@@ -530,7 +530,7 @@ positive_integer = digit+ ;
 grain_type_plural   = "beliefs" | "events" | "states" | "workflows" | "actions"
                     | "observations" | "goals" | "reasonings" | "consensuses" | "consents" ;
 
-grain_type_singular = "belief" | "event" | "state" | "workflow" | "action"
+grain_type_singular = "fact" | "event" | "state" | "workflow" | "tool"
                     | "observation" | "goal" | "reasoning" | "consensus" | "consent" ;
 ```
 
@@ -542,11 +542,11 @@ grain_type_singular = "belief" | "event" | "state" | "workflow" | "action"
 
 | Type | Plural (after RECALL) | Singular (in ADD/WHERE) | OMS Type Code |
 |------|----------------------|------------------------|---------------|
-| Belief | `beliefs` | `belief` | 0x01 |
+| Fact | `facts` | `fact` | 0x01 |
 | Event | `events` | `event` | 0x02 |
 | State | `states` | `state` | 0x03 |
 | Workflow | `workflows` | `workflow` | 0x04 |
-| Action | `actions` | `action` | 0x05 |
+| Tool | `tools` | `tool` | 0x05 |
 | Observation | `observations` | `observation` | 0x06 |
 | Goal | `goals` | `goal` | 0x07 |
 | Reasoning | `reasonings` | `reasoning` | 0x08 |
@@ -610,7 +610,7 @@ Missing field = no match (never errors). `WHERE confidence >= 0.8` on a grain wi
 
 ### 6.1 Design Principle
 
-When a `RECALL` statement specifies a grain type (e.g., `RECALL actions`), the parser unlocks a **type-specific field set** for use in `WHERE` clauses. This enables precise querying of OMS-native fields that only exist on specific grain types, without polluting the global field namespace.
+When a `RECALL` statement specifies a grain type (e.g., `RECALL tools`), the parser unlocks a **type-specific field set** for use in `WHERE` clauses. This enables precise querying of OMS-native fields that only exist on specific grain types, without polluting the global field namespace.
 
 The type-specific field set is a **compile-time guarantee**: the parser MUST reject field references that do not belong to the specified grain type. When no grain type is specified (`RECALL WHERE ...`), only the common field set is available.
 
@@ -623,9 +623,9 @@ The type-specific field set is a **compile-time guarantee**: the parser MUST rej
 
 ### 6.3 Grain-Type-Specific Queryable Fields
 
-#### Belief (0x01) -- `RECALL beliefs`
+#### Fact (0x01) -- `RECALL facts`
 
-All Belief fields are in the common set (`subject`, `relation`, `object`, `confidence`). No additional type-specific fields.
+All Fact fields are in the common set (`subject`, `relation`, `object`, `confidence`). No additional type-specific fields.
 
 #### Event (0x02) -- `RECALL events`
 
@@ -650,16 +650,16 @@ All Belief fields are in the common set (`subject`, `relation`, `object`, `confi
 |-------|------|-----------|-------|
 | `trigger` | String | `=`, `!=` | Trigger condition (e.g., `"on:merge_to_main"`) |
 | `node` | String | `=` | Match workflows containing a specific node |
-| `binding` | String | `=` | Match workflows binding to a specific Action grain hash |
+| `binding` | String | `=` | Match workflows binding to a specific Tool grain hash |
 
-#### Action (0x05) -- `RECALL actions`
+#### Tool (0x05) -- `RECALL tools`
 
 | Field | Type | Operators | Notes |
 |-------|------|-----------|-------|
 | `tool_name` | String | `=`, `!=`, `IN` | Tool identifier |
-| `action_phase` | String | `=` | `"definition"`, `"call"`, `"result"`, `"complete"` |
-| `is_error` | Boolean | `=` | Whether the action resulted in error |
-| `tool_call_id` | String | `=` | Correlation ID across action phases |
+| `tool_phase` | String | `=` | `"definition"`, `"call"`, `"result"`, `"complete"` |
+| `is_error` | Boolean | `=` | Whether the tool resulted in error |
+| `tool_call_id` | String | `=` | Correlation ID across tool phases |
 
 #### Observation (0x06) -- `RECALL observations`
 
@@ -733,11 +733,11 @@ ADD observation
 
 | Grain Type | Common Fields | Type-Specific Fields | Total Queryable |
 |-----------|--------------|---------------------|----------------|
-| Belief | 18 | 0 | 18 |
+| Fact | 18 | 0 | 18 |
 | Event | 18 | 5 | 23 |
 | State | 18 | 2 | 20 |
 | Workflow | 18 | 2 | 20 |
-| Action | 18 | 4 | 22 |
+| Tool | 18 | 4 | 22 |
 | Observation | 18 | 2 | 20 |
 | Goal | 18 | 4 | 22 |
 | Reasoning | 18 | 3 | 21 |
@@ -795,7 +795,7 @@ CAL defines **relation category shortcuts** as syntactic sugar for common multi-
 
 ```sql
 -- All preference-related beliefs about alice
-RECALL beliefs WHERE subject = "alice" AND relation IS PREFERENCE
+RECALL facts WHERE subject = "alice" AND relation IS PREFERENCE
   ORDER BY confidence DESC
 
 -- All permission records for a DID
@@ -832,7 +832,7 @@ CAL/1 has **12 statement types** organized into three tiers:
 Retrieves grains matching the given filters. Returns results using the OMS Standard Search Response Envelope.
 
 ```sql
-RECALL beliefs WHERE subject = "alice" AND relation = "prefers"
+RECALL facts WHERE subject = "alice" AND relation = "prefers"
   WITH contradiction_detection
   ORDER BY confidence DESC
   LIMIT 10
@@ -842,11 +842,11 @@ RECALL supports semantic shortcuts (ABOUT, RECENT, SINCE, LIKE, MY, CONTRADICTIO
 
 ```sql
 -- With grain-type-specific fields
-RECALL actions WHERE tool_name = "get_weather" AND is_error = false
+RECALL tools WHERE tool_name = "get_weather" AND is_error = false
   ORDER BY time DESC LIMIT 20
 
 -- With domain profile fields
-RECALL beliefs WHERE tags INCLUDE ["profile:healthcare"]
+RECALL facts WHERE tags INCLUDE ["profile:healthcare"]
   AND hc:patient_id = "P-12345" AND relation = "mg:knows"
 ```
 
@@ -871,10 +871,10 @@ The flagship new statement. Composes a context block from multiple RECALL source
 CAL/1 ASSEMBLE user_context
   FOR "conversation about alice's preferences and goals"
   FROM
-    beliefs:  (RECALL beliefs ABOUT "alice" WHERE relation = "prefers" LIMIT 20),
+    beliefs:  (RECALL facts ABOUT "alice" WHERE relation = "prefers" LIMIT 20),
     goals:    (RECALL goals ABOUT "alice" RECENT 10),
     events:   (RECALL events WHERE user_id = "alice" RECENT 5),
-    history:  (RECALL beliefs ABOUT "alice"
+    history:  (RECALL facts ABOUT "alice"
                 WHERE relation = "prefers" WITH superseded
                 ORDER BY time DESC LIMIT 3)
   BUDGET 2000 tokens
@@ -943,10 +943,10 @@ HISTORY sha256:aaa... DIFF sha256:bbb...
 Returns the execution plan without running the query. Works with all statement types including ASSEMBLE.
 
 ```sql
-EXPLAIN RECALL beliefs WHERE query = "alice preferences" LIMIT 10
+EXPLAIN RECALL facts WHERE query = "alice preferences" LIMIT 10
 EXPLAIN ASSEMBLE user_context
   FOR "conversation about alice"
-  FROM beliefs: (RECALL beliefs ABOUT "alice"),
+  FROM beliefs: (RECALL facts ABOUT "alice"),
        goals: (RECALL goals ABOUT "alice" RECENT 5)
   BUDGET 2000 tokens
 ```
@@ -958,7 +958,7 @@ Schema introspection for grain types, fields, capabilities, server metadata, tem
 ```sql
 CAL/1 DESCRIBE grain_types        -- list available grain types
 CAL/1 DESCRIBE fields             -- list all queryable fields
-CAL/1 DESCRIBE fields belief      -- list fields for a specific grain type
+CAL/1 DESCRIBE fields fact      -- list fields for a specific grain type
 CAL/1 DESCRIBE capabilities       -- server capabilities and conformance
 CAL/1 DESCRIBE server             -- server metadata
 CAL/1 DESCRIBE templates          -- list registered templates
@@ -971,9 +971,9 @@ Multiple independent queries in a single request. Each sub-query gets its own re
 
 ```sql
 CAL/1 BATCH {
-  preferences: RECALL beliefs ABOUT "alice" WHERE relation = "prefers",
+  preferences: RECALL facts ABOUT "alice" WHERE relation = "prefers",
   recent:      RECALL events ABOUT "alice" RECENT 5,
-  team:        RECALL beliefs WHERE relation = "member_of" AND object = "team-alpha"
+  team:        RECALL facts WHERE relation = "member_of" AND object = "team-alpha"
 }
 ```
 
@@ -984,7 +984,7 @@ CAL/1 BATCH {
 Creates a **new** grain. Pure append-only -- does not modify or reference any existing grain.
 
 ```sql
-ADD belief
+ADD fact
   SET subject = "alice"
   SET relation = "prefers"
   SET object = "dark mode"
@@ -993,9 +993,9 @@ ADD belief
   REASON "user stated preference during onboarding conversation"
 ```
 
-**Addable grain types:** Belief, Observation, Goal, Workflow. Events, Actions, States, and other types represent system-generated records and are not user-creatable.
+**Addable grain types:** Fact, Observation, Goal, Workflow. Events, Tools, States, and other types represent system-generated records and are not user-creatable.
 
-**Required SET fields (Belief):** `subject`, `relation`, `object`. `REASON` is mandatory.
+**Required SET fields (Fact):** `subject`, `relation`, `object`. `REASON` is mandatory.
 
 #### 8.8.1 ADD Workflow (Graph Syntax)
 
@@ -1058,7 +1058,7 @@ ADD workflow "release pipeline"
 
 **Structural inference:** Node types are inferred from graph topology — a node with multiple unconditional outgoing edges is a fork, a node receiving multiple edges is an AND-join, a node with `WHEN` edges is a decision point.
 
-**BIND clause:** Maps a node name to an Action definition grain hash (`action_phase: "definition"`). The executor fetches the definition to discover `tool_name`, `input_schema`, etc. Unbound nodes are resolved by name convention or treated as abstract steps.
+**BIND clause:** Maps a node name to an Tool definition grain hash (`tool_phase: "definition"`). The executor fetches the definition to discover `tool_name`, `input_schema`, etc. Unbound nodes are resolved by name convention or treated as abstract steps.
 
 **Node names:** Bare identifiers (`build`, `unit_test`) or quoted strings (`"send welcome email"`). Reserved words (`ADD`, `workflow`, `ON`, `WHEN`, `BIND`, `REASON`, `BECAUSE`) must be quoted.
 
@@ -1073,7 +1073,7 @@ SUPERSEDE sha256:target_hash
   REASON "user explicitly changed preference"
 ```
 
-**Belief supersession:** At least one `SET` clause and `REASON` are required.
+**Fact supersession:** At least one `SET` clause and `REASON` are required.
 
 **Workflow supersession:** Uses graph syntax (full graph replacement):
 
@@ -1117,10 +1117,10 @@ LET bindings name intermediate RECALL results that can be referenced by `$name` 
 
 ```sql
 CAL/1
-LET $team_members = RECALL beliefs
+LET $team_members = RECALL facts
   WHERE relation = "member_of" AND object = "team-alpha" SUBJECTS;
 
-LET $team_prefs = RECALL beliefs
+LET $team_prefs = RECALL facts
   WHERE subject IN ($team_members) AND relation = "prefers";
 
 ASSEMBLE team_context
@@ -1145,10 +1145,10 @@ Evaluates argument queries left-to-right. Returns the result of the **first quer
 
 ```sql
 COALESCE(
-  RECALL beliefs WHERE subject = "alice" AND relation = "favorite_color",
-  RECALL beliefs WHERE subject = "alice" AND relation = "prefers"
+  RECALL facts WHERE subject = "alice" AND relation = "favorite_color",
+  RECALL facts WHERE subject = "alice" AND relation = "prefers"
     AND tags INCLUDE ["color"],
-  RECALL beliefs ABOUT "alice" LIKE "color preference"
+  RECALL facts ABOUT "alice" LIKE "color preference"
 )
 ```
 
@@ -1163,9 +1163,9 @@ Shortcuts are **syntactic sugar** -- they desugar to standard WHERE/pipeline cla
 ### 9.1 ABOUT
 
 ```sql
-RECALL beliefs ABOUT "alice"
--- Desugars to: RECALL beliefs WHERE subject = "alice"
--- Falls back to: RECALL beliefs WHERE query = "alice" (if no structural match)
+RECALL facts ABOUT "alice"
+-- Desugars to: RECALL facts WHERE subject = "alice"
+-- Falls back to: RECALL facts WHERE query = "alice" (if no structural match)
 ```
 
 ### 9.2 RECENT
@@ -1193,14 +1193,14 @@ RECALL LIKE "machine learning best practices"
 
 ```sql
 RECALL MY beliefs
--- Desugars to: RECALL beliefs WHERE user_id = $current_user_id
+-- Desugars to: RECALL facts WHERE user_id = $current_user_id
 ```
 
 ### 9.6 CONTRADICTIONS
 
 ```sql
-RECALL beliefs ABOUT "alice" CONTRADICTIONS
--- Desugars to: RECALL beliefs WHERE subject = "alice" AND contradicted = true
+RECALL facts ABOUT "alice" CONTRADICTIONS
+-- Desugars to: RECALL facts WHERE subject = "alice" AND contradicted = true
 --              WITH contradiction_detection
 ```
 
@@ -1248,15 +1248,15 @@ The `FORMAT` and `AS` clauses accept either a single format name or a bracketed 
 **Single format** (existing behavior):
 
 ```
-CAL/1 RECALL beliefs ABOUT "alice" FORMAT markdown
-CAL/1 RECALL beliefs ABOUT "alice" AS json
+CAL/1 RECALL facts ABOUT "alice" FORMAT markdown
+CAL/1 RECALL facts ABOUT "alice" AS json
 ```
 
 **Multi-format:**
 
 ```
-CAL/1 RECALL beliefs ABOUT "alice" FORMAT [markdown, json]
-CAL/1 RECALL beliefs ABOUT "alice" AS [markdown, json]
+CAL/1 RECALL facts ABOUT "alice" FORMAT [markdown, json]
+CAL/1 RECALL facts ABOUT "alice" AS [markdown, json]
 ```
 
 **Multi-format with aliases:**
@@ -1264,9 +1264,9 @@ CAL/1 RECALL beliefs ABOUT "alice" AS [markdown, json]
 Each format in a bracketed list MAY include an `AS <identifier>` alias. When present, the alias becomes the key in the multi-format response object (Section 14.2.1) instead of the canonical format name. Aliases are particularly useful when the list contains multiple templates (which would otherwise all share the key `"template"`) or when the client wants semantically meaningful keys.
 
 ```
-CAL/1 RECALL beliefs FORMAT [json AS customers, markdown AS report]
-CAL/1 RECALL beliefs FORMAT [json AS structured, TEMPLATE "{{subject}}: {{object}}" AS oneliner]
-CAL/1 RECALL beliefs FORMAT [TEMPLATE "{{subject}}" AS names, TEMPLATE "{{object}}" AS values]
+CAL/1 RECALL facts FORMAT [json AS customers, markdown AS report]
+CAL/1 RECALL facts FORMAT [json AS structured, TEMPLATE "{{subject}}: {{object}}" AS oneliner]
+CAL/1 RECALL facts FORMAT [TEMPLATE "{{subject}}" AS names, TEMPLATE "{{object}}" AS values]
 ```
 
 **Rules:**
@@ -1307,10 +1307,10 @@ Each grain type defines a **content rule** (what becomes the text content of the
 
 | Grain Type | Text Content Rule | Default Attributes |
 |-----------|------------------|-------------------|
-| **Belief** | `humanize(relation) + " " + object` | `subject`, `confidence`? |
+| **Fact** | `humanize(relation) + " " + object` | `subject`, `confidence`? |
 | **Event** | `content` | `role`, `time`? |
 | **Goal** | `object` (the objective description) | `subject`, `state`?, `deadline`? |
-| **Action** | `object` (tool result summary) | `tool`, `phase`? |
+| **Tool** | `object` (tool result summary) | `tool`, `phase`? |
 | **Observation** | `object` (what was observed) | `observer`? |
 | **Reasoning** | `conclusion` | `type`? |
 | **State** | `plan` (summary) | `context`? |
@@ -1350,7 +1350,7 @@ Full ISO 8601 timestamps remain in the machine envelope. Implementations MAY pro
 The `PROJECT` clause overrides default content projection, allowing queries to surface custom or domain-specific fields:
 
 ```sql
-CAL/1 RECALL beliefs ABOUT "alice"
+CAL/1 RECALL facts ABOUT "alice"
   PROJECT content(relation, object), attr(confidence, x_department)
   LIMIT 10 AS sml
 ```
@@ -1463,7 +1463,7 @@ CAL/1 DEFINE TEMPLATE semantic_sml
 ```sql
 CAL/1 ASSEMBLE conversation_context
   FOR "helping alice with her project"
-  FROM beliefs: (RECALL beliefs ABOUT "alice" LIMIT 20),
+  FROM beliefs: (RECALL facts ABOUT "alice" LIMIT 20),
        goals: (RECALL goals ABOUT "alice" RECENT 5)
   BUDGET 3000 tokens
   FORMAT TEMPLATE semantic_sml
@@ -1482,9 +1482,9 @@ FORMAT TEMPLATE {
 ```sml
 <context intent="helping alice prepare her Q1 engineering review">
 
-  <belief subject="alice" confidence="0.95">prefers dark mode in all tools</belief>
-  <belief subject="alice" confidence="0.88">requires keyboard shortcuts for productivity</belief>
-  <belief subject="alice" confidence="0.82">works best in deep-focus blocks of 90 minutes</belief>
+  <fact subject="alice" confidence="0.95">prefers dark mode in all tools</fact>
+  <fact subject="alice" confidence="0.88">requires keyboard shortcuts for productivity</fact>
+  <fact subject="alice" confidence="0.82">works best in deep-focus blocks of 90 minutes</fact>
 
   <goal subject="alice" state="active" deadline="2026-03-15">complete Q1 engineering review presentation</goal>
   <goal subject="alice" state="active">reduce P0 incident rate by 20% in Q2</goal>
@@ -1493,8 +1493,8 @@ FORMAT TEMPLATE {
   <event role="assistant" time="10m ago">Sure — retrieving deployment counts, incident data, and velocity now.</event>
   <event role="user" time="8m ago">Focus on the reliability numbers first.</event>
 
-  <action tool="query_metrics" phase="completed">retrieved 47 deployments and 3 P0 incidents for Q1 2026</action>
-  <action tool="search_docs" phase="completed">found Q1 review template in confluence/engineering/reviews</action>
+  <tool tool="query_metrics" phase="completed">retrieved 47 deployments and 3 P0 incidents for Q1 2026</tool>
+  <tool tool="search_docs" phase="completed">found Q1 review template in confluence/engineering/reviews</tool>
 
   <observation observer="system">alice opened incident-dashboard at 09:14 UTC</observation>
   <observation observer="system" source="calendar">Q1 review presentation scheduled for 2026-03-15 14:00 UTC</observation>
@@ -1556,7 +1556,7 @@ TOON is complementary to SML, not a replacement:
 
 | Property | SML | TOON |
 |----------|-----|------|
-| Semantic tag names | Yes (`<belief>`, `<goal>`, …) | No — grain type in section header only |
+| Semantic tag names | Yes (`<fact>`, `<goal>`, …) | No — grain type in section header only |
 | Token efficiency | Moderate | High (~40% fewer vs JSON) |
 | Uniform arrays | One element per line | CSV table — optimal |
 | Mixed grain types | Natural (each type has its own tag) | Grouped sections |
@@ -1612,7 +1612,7 @@ Where:
 At `summary` disclosure, `confidence`, `state`, `phase`, and `type` columns are omitted.
 At `full` disclosure, additional columns `source` and `observed` are appended.
 
-**Example — `RECALL beliefs ABOUT "alice" LIMIT 3 AS toon`:**
+**Example — `RECALL facts ABOUT "alice" LIMIT 3 AS toon`:**
 ```
 beliefs[3]{subject,content,confidence}:
 alice,prefers dark mode,0.95
@@ -1753,7 +1753,7 @@ assembly_started
 
 ```sql
 ASSEMBLE user_context
-  FROM beliefs: (RECALL beliefs ABOUT "alice")
+  FROM beliefs: (RECALL facts ABOUT "alice")
   BUDGET 2000 tokens
   STREAM { all }                              -- all events
   -- or: STREAM { progress, chunks }          -- specific events
@@ -1852,7 +1852,7 @@ OMS defines domain profiles (healthcare, legal, finance, robotics, science, cons
 
 ```sql
 RECALL WHERE tags INCLUDE ["profile:healthcare"]
-RECALL beliefs WHERE tags INCLUDE ["profile:healthcare"]
+RECALL facts WHERE tags INCLUDE ["profile:healthcare"]
   AND subject = "patient:P-12345" AND relation IS PREFERENCE
 ```
 
@@ -1872,7 +1872,7 @@ Domain-specific fields use OMS domain prefix convention:
 
 **Example:**
 ```sql
-RECALL beliefs WHERE tags INCLUDE ["profile:healthcare"]
+RECALL facts WHERE tags INCLUDE ["profile:healthcare"]
   AND hc:patient_id = "P-12345"
   AND hc:condition_code IN ("J06.9", "J20.9")
   AND relation = "mg:knows"
@@ -1936,8 +1936,8 @@ A formatted representation for direct insertion into LLM context windows. The co
 ```sml
 <context intent="helping alice with project">
 
-  <belief subject="alice" confidence="0.92">prefers dark mode</belief>
-  <belief subject="alice" confidence="0.88">requires keyboard shortcuts</belief>
+  <fact subject="alice" confidence="0.92">prefers dark mode</fact>
+  <fact subject="alice" confidence="0.88">requires keyboard shortcuts</fact>
 
   <goal subject="alice" state="active">complete Q1 review</goal>
 
@@ -1948,7 +1948,7 @@ A formatted representation for direct insertion into LLM context windows. The co
 ```markdown
 ## Context: helping alice with project
 
-**Beliefs**
+**Facts**
 - alice prefers dark mode (confidence: 0.92)
 - alice requires keyboard shortcuts (confidence: 0.88)
 
@@ -1958,8 +1958,8 @@ A formatted representation for direct insertion into LLM context windows. The co
 
 **Compact format** (for `compact` / `text`):
 ```
-[belief] alice prefers dark mode (0.92)
-[belief] alice requires keyboard shortcuts (0.88)
+[fact] alice prefers dark mode (0.92)
+[fact] alice requires keyboard shortcuts (0.88)
 [goal] alice: complete Q1 review (active)
 ```
 
@@ -1978,7 +1978,7 @@ When the query specifies a format list (`FORMAT [markdown, json]`), the response
     "duration_ms": 38
   },
   "formats": {
-    "markdown": "## Beliefs\n- alice prefers dark mode (confidence: 0.92)\n",
+    "markdown": "## Facts\n- alice prefers dark mode (confidence: 0.92)\n",
     "json": [
       {"subject": "alice", "relation": "prefers", "object": "dark mode", "confidence": 0.92}
     ]
@@ -2020,10 +2020,10 @@ Each grain type projects its fields into a **text content** string and **attribu
 
 | Grain Type | Projected Text Content | Example Output (sml) |
 |-----------|----------------------|---------------------|
-| Belief | `humanize(relation) + " " + object` | `<belief subject="alice" confidence="0.95">prefers dark mode in all tools</belief>` |
+| Fact | `humanize(relation) + " " + object` | `<fact subject="alice" confidence="0.95">prefers dark mode in all tools</fact>` |
 | Event | `content` | `<event role="user" time="10m ago">Can you help me pull together the Q1 metrics?</event>` |
 | Goal | `object` | `<goal subject="alice" state="active" deadline="2026-03-15">complete Q1 engineering review presentation</goal>` |
-| Action | `object` (tool result) | `<action tool="query_metrics" phase="completed">retrieved 47 deployments and 3 P0 incidents for Q1 2026</action>` |
+| Tool | `object` (tool result) | `<tool tool="query_metrics" phase="completed">retrieved 47 deployments and 3 P0 incidents for Q1 2026</tool>` |
 | Observation | `object` | `<observation observer="system">alice opened incident-dashboard at 09:14 UTC</observation>` |
 | Reasoning | `conclusion` | `<reasoning type="deductive">alice is prioritising reliability given 3 P0 incidents; lead with incident reduction narrative</reasoning>` |
 | State | `plan` summary | `<state context="q1_review_prep">outlining slides: 1. headline metrics  2. incident retrospective  3. velocity trend  4. Q2 goals</state>` |
@@ -2050,7 +2050,7 @@ Every valid CAL statement has exactly one representation in each format, and con
 
 **text/cal:**
 ```
-CAL/1 RECALL beliefs ABOUT "alice" WHERE confidence >= 0.8 RECENT 5 AS markdown
+CAL/1 RECALL facts ABOUT "alice" WHERE confidence >= 0.8 RECENT 5 AS markdown
 ```
 
 **application/json+cal:**
@@ -2116,7 +2116,7 @@ Implementations MUST declare cross-lingual capability in `DESCRIBE capabilities`
 Default: Unicode code point order (binary sort). Locale-aware sorting requested via `WITH locale("xx")`:
 
 ```sql
-RECALL beliefs ABOUT "alice" ORDER BY object ASC WITH locale("de")
+RECALL facts ABOUT "alice" ORDER BY object ASC WITH locale("de")
 ```
 
 Locale-aware sorting is optional. Implementations that do not support it MUST ignore the `locale()` option with a warning.
@@ -2247,7 +2247,7 @@ CAL String (ADD, SUPERSEDE, or REVERT)
   "issued_at": 1709337600000,
   "expires_at": 1709337900000,
   "max_uses": 1,
-  "allowed_grain_types": ["belief"],
+  "allowed_grain_types": ["fact"],
   "write_quota_remaining": 10,
   "signature": "hmac-sha256-signature"
 }
@@ -2400,9 +2400,9 @@ Errors are stable across spec versions. Every error MUST include: code, message,
     "code": "CAL-E003",
     "message": "Unknown grain type \"fact\".",
     "position": {"start": 7, "end": 11, "line": 1, "col": 8},
-    "suggestion": "Did you mean \"belief\"? (OMS renamed Fact -> Belief in v1.2)",
-    "example": "RECALL beliefs WHERE subject = \"alice\"",
-    "valid_values": ["belief","event","state","workflow","action","observation","goal","reasoning","consensus","consent"]
+    "suggestion": "Did you mean \"fact\"? (OMS renamed Belief -> Fact in v1.4)",
+    "example": "RECALL facts WHERE subject = \"alice\"",
+    "valid_values": ["fact","event","state","workflow","tool","observation","goal","reasoning","consensus","consent"]
   }
 }
 ```
@@ -2615,7 +2615,7 @@ It can read, assemble, and evolve memories, but never delete them.
   time BETWEEN epoch1 AND epoch2  -- epoch range
   confidence >= 0.8               -- min confidence
   tags INCLUDE ["tag1"]           -- required tags
-  type = "belief"                 -- grain type
+  type = "fact"                 -- grain type
 
 ### Shortcuts: ABOUT, RECENT n, SINCE, LIKE, MY, CONTRADICTIONS, BETWEEN
 
@@ -2638,7 +2638,7 @@ It can read, assemble, and evolve memories, but never delete them.
   FORMAT [TEMPLATE "{{subject}}" AS names, TEMPLATE "{{object}}" AS values]
 
 ### Output formats:
-  sml (default structured): flat tag-based — <belief subject="alice" confidence="0.92">prefers dark mode</belief>
+  sml (default structured): flat tag-based — <fact subject="alice" confidence="0.92">prefers dark mode</fact>
   toon: CSV-tabular, ~40% fewer tokens — beliefs[3]{subject,content,confidence}:\nalice,prefers dark mode,0.95
   markdown: human-readable prose
   json: machine-readable structured data
@@ -2712,7 +2712,7 @@ All error codes use the `CAL-E` prefix.
 |------|-------------|
 | CAL-E020 | Incompatible types in comparison |
 | CAL-E021 | Pipeline stage type mismatch |
-| CAL-E022 | SUBJECTS/OBJECTS requires belief-type input |
+| CAL-E022 | SUBJECTS/OBJECTS requires fact-type input |
 
 ### Execution Errors (CAL-E030 -- CAL-E031)
 
@@ -2727,13 +2727,13 @@ All error codes use the `CAL-E` prefix.
 |------|-------------|
 | CAL-E040 | SupersessionConflict -- target grain already superseded |
 | CAL-E041 | NoPreviousVersion -- REVERT target is the original grain |
-| CAL-E042 | GrainTypeNotEvolvable -- only Belief grains can be superseded |
+| CAL-E042 | GrainTypeNotEvolvable -- only Fact grains can be superseded |
 | CAL-E043 | WriteQuotaExceeded -- too many evolve operations |
 | CAL-E044 | Tier1NotEnabled -- requires Tier 1 capability |
 | CAL-E045 | NamespaceMismatch -- target grain in different namespace |
 | CAL-E046 | TargetNotFound -- target hash does not exist |
 | CAL-E050 | MissingRequiredField -- ADD requires subject, relation, object |
-| CAL-E051 | GrainTypeNotAddable -- only Belief, Observation, Goal can be created |
+| CAL-E051 | GrainTypeNotAddable -- only Fact, Observation, Goal can be created |
 | CAL-E052 | AddQuotaExceeded -- too many ADD operations |
 
 ### Multi-Format Errors (CAL-E110, CAL-E113)
@@ -2749,7 +2749,7 @@ All error codes use the `CAL-E` prefix.
 |------|-------------|
 | CAL-E060 | AmbiguousShortcut / FieldNotOnGrainType |
 | CAL-E061 | Grain-type-specific field used without declaring grain type |
-| CAL-E062 | Invalid `action_phase` value |
+| CAL-E062 | Invalid `tool_phase` value |
 | CAL-E063 | Invalid `goal_state` value |
 | CAL-E064 | Invalid `consent_action` value |
 | CAL-E065 | Invalid `recall_priority` value |
@@ -2892,10 +2892,10 @@ CHUNK, PAUSE, RESUME, CANCEL
 | Workflow | `trigger` | String | `=`, `!=` |
 | Workflow | `node` | String | `=` |
 | Workflow | `binding` | String | `=` |
-| Action | `tool_name` | String | `=`, `!=`, `IN` |
-| Action | `action_phase` | String | `=` |
-| Action | `is_error` | Boolean | `=` |
-| Action | `tool_call_id` | String | `=` |
+| Tool | `tool_name` | String | `=`, `!=`, `IN` |
+| Tool | `tool_phase` | String | `=` |
+| Tool | `is_error` | Boolean | `=` |
+| Tool | `tool_call_id` | String | `=` |
 | Observation | `observer_id` | String | `=`, `!=` |
 | Observation | `observer_type` | String | `=`, `!=` |
 | Goal | `goal_state` | String | `=`, `!=` |
@@ -2938,7 +2938,7 @@ CHUNK, PAUSE, RESUME, CANCEL
 
 ---
 
-**Document Status:** This is the CAL (Context Assembly Language) Specification v1.0. It defines a non-destructive, deterministic, LLM-native context assembly and evolution language for OMS-compliant memory databases. CAL is part of the Open Memory Specification (OMS) v1.3 — see [SPECIFICATION.md](./SPECIFICATION.md).
+**Document Status:** This is the CAL (Context Assembly Language) Specification v1.0. It defines a non-destructive, deterministic, LLM-native context assembly and evolution language for OMS-compliant memory databases. CAL is part of the Open Memory Specification (OMS) v1.4 — see [SPECIFICATION.md](./SPECIFICATION.md).
 
 **Last Updated:** 2026-03-05
 **License:** This specification is offered under the Open Web Foundation Final Specification Agreement (OWFa 1.0)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ OMS is an open standard for portable, auditable, and interoperable agent memory.
 
 ## OMS — The Memory Format
 
-OMS defines the **Memory Grain (`.mg`) container** — a binary format for immutable, content-addressed knowledge units called *grains*. A memory grain is the atomic unit of agent knowledge: a single immutable belief, event, observation, or decision record, identified by the SHA-256 hash of its canonical binary representation.
+OMS defines the **Memory Grain (`.mg`) container** — a binary format for immutable, content-addressed knowledge units called *grains*. A memory grain is the atomic unit of agent knowledge: a single immutable fact, event, observation, or decision record, identified by the SHA-256 hash of its canonical binary representation.
 
 Think of the `.mg` container as what JSON is to APIs or `.git` objects are to version control — a universal, language-agnostic, self-describing interchange format for agent memory.
 
@@ -38,7 +38,7 @@ Think of the `.mg` container as what JSON is to APIs or `.git` objects are to ve
 
 | Type | Byte | Description |
 |------|------|-------------|
-| Belief | `0x01` | Declarative knowledge: subject–relation–object triple |
+| Fact | `0x01` | Declarative knowledge: subject–relation–object triple |
 | Event | `0x02` | Timestamped occurrence: message, interaction, or utterance |
 | State | `0x03` | Agent state snapshot at a point in time |
 | Workflow | `0x04` | Directed graph of procedural steps |
@@ -108,7 +108,7 @@ A support agent handles an inbound ticket: *"My invoice shows a charge I don't r
 CAL/1 ASSEMBLE support_context
   FOR "resolving billing dispute for customer:priya"
   FROM
-    profile:   (RECALL beliefs  ABOUT "customer:priya"
+    profile:   (RECALL facts  ABOUT "customer:priya"
                 WHERE relation IS KNOWLEDGE
                 LIMIT 10),
     history:   (RECALL events
@@ -119,7 +119,7 @@ CAL/1 ASSEMBLE support_context
                 WHERE subject = "customer:priya"
                   AND tags INCLUDE ["support:billing"]
                 RECENT 5),
-    policy:    (RECALL beliefs
+    policy:    (RECALL facts
                 WHERE tags INCLUDE ["policy:billing"]
                 LIMIT 5),
     session:   (RECALL actions
@@ -160,13 +160,13 @@ CAL/1 RECALL workflows
 
 ## SML — Semantic Markup Language
 
-SML is the output format produced by CAL `ASSEMBLE FORMAT sml`. It is a **flat, tag-based markup format** designed for direct LLM consumption. Tag names are OMS grain types (`<belief>`, `<event>`, `<reasoning>`, …). The tag tells the LLM the epistemic status of the content; the attributes carry decision metadata; the element text is natural-language prose.
+SML is the output format produced by CAL `ASSEMBLE FORMAT sml`. It is a **flat, tag-based markup format** designed for direct LLM consumption. Tag names are OMS grain types (`<fact>`, `<event>`, `<reasoning>`, …). The tag tells the LLM the epistemic status of the content; the attributes carry decision metadata; the element text is natural-language prose.
 
 SML is **not XML**. It requires no parser, no schema, no escape sequences. An LLM reads it the same way a person reads a well-structured document.
 
 ### Structural Rules
 
-1. **Tag names are grain types.** `<belief>`, `<goal>`, `<event>`, `<action>`, `<observation>`, `<reasoning>`, `<state>`, `<workflow>`, `<consensus>`, `<consent>` — no others.
+1. **Tag names are grain types.** `<fact>`, `<goal>`, `<event>`, `<action>`, `<observation>`, `<reasoning>`, `<state>`, `<workflow>`, `<consensus>`, `<consent>` — no others.
 2. **Flat only.** No nesting beyond the `<context>` envelope.
 3. **No storage internals.** No hashes, namespaces, or OMS metadata in the output.
 4. **Natural language content.** Element text is prose, not decomposed triples.
@@ -179,9 +179,9 @@ This is the SML block injected into the LLM system prompt for the billing disput
 ```sml
 <context intent="resolving billing dispute for customer:priya">
 
-  <belief subject="customer:priya" confidence="0.97">account tier is Professional, annual billing cycle</belief>
-  <belief subject="customer:priya" confidence="0.93">primary contact email is priya@example.com</belief>
-  <belief subject="customer:priya" confidence="0.89">enrolled in auto-renewal since 2024-03-01</belief>
+  <fact subject="customer:priya" confidence="0.97">account tier is Professional, annual billing cycle</fact>
+  <fact subject="customer:priya" confidence="0.93">primary contact email is priya@example.com</fact>
+  <fact subject="customer:priya" confidence="0.89">enrolled in auto-renewal since 2024-03-01</fact>
 
   <event role="user"  time="2m ago">My invoice shows a charge I don't recognise — $299 on 28 Feb.</event>
   <event role="agent" time="2m ago">Looking into that now, Priya. Retrieving your billing history.</event>
@@ -199,7 +199,7 @@ This is the SML block injected into the LLM system prompt for the billing disput
   <reasoning type="deductive">charge is the annual plan renewal; customer enrolled in auto-renewal; charge is valid</reasoning>
   <reasoning type="abductive">customer may be unaware of annual cycle because last billing interaction was January — explain renewal cadence before offering monthly switch</reasoning>
 
-  <belief subject="policy:billing" confidence="1.0">customers may switch billing cycle within 30 days of renewal with pro-rated refund</belief>
+  <fact subject="policy:billing" confidence="1.0">customers may switch billing cycle within 30 days of renewal with pro-rated refund</fact>
 
   <consent action="granted" grantor="customer:priya" grantee="support-agent">access billing records and invoice history for dispute resolution</consent>
 
@@ -214,9 +214,9 @@ SML metadata density is controlled by disclosure level — the element shape nev
 
 | Level | Example |
 |-------|---------|
-| `summary` | `<belief subject="customer:priya">enrolled in auto-renewal</belief>` |
-| `standard` | `<belief subject="customer:priya" confidence="0.89">enrolled in auto-renewal since 2024-03-01</belief>` |
-| `full` | `<belief subject="customer:priya" confidence="0.89" source="crm" observed="14d ago">enrolled in auto-renewal since 2024-03-01</belief>` |
+| `summary` | `<fact subject="customer:priya">enrolled in auto-renewal</fact>` |
+| `standard` | `<fact subject="customer:priya" confidence="0.89">enrolled in auto-renewal since 2024-03-01</fact>` |
+| `full` | `<fact subject="customer:priya" confidence="0.89" source="crm" observed="14d ago">enrolled in auto-renewal since 2024-03-01</fact>` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Memory Specification (OMS)
 
-**Version:** 1.3 | **Status:** Standards Track | **License:** CC0 1.0 Universal (Public Domain)
+**Version:** 1.4 | **Status:** Standards Track | **License:** CC0 1.0 Universal (Public Domain)
 
 Backed by [areev.ai](https://areev.ai).
 
@@ -42,7 +42,7 @@ Think of the `.mg` container as what JSON is to APIs or `.git` objects are to ve
 | Event | `0x02` | Timestamped occurrence: message, interaction, or utterance |
 | State | `0x03` | Agent state snapshot at a point in time |
 | Workflow | `0x04` | Directed graph of procedural steps |
-| Action | `0x05` | Tool invocation or code execution |
+| Tool | `0x05` | Tool invocation or code execution |
 | Observation | `0x06` | Sensor or cognitive input |
 | Goal | `0x07` | Intent, objective, or desired outcome |
 | Reasoning | `0x08` | Inference chain and thought audit trail |
@@ -122,7 +122,7 @@ CAL/1 ASSEMBLE support_context
     policy:    (RECALL facts
                 WHERE tags INCLUDE ["policy:billing"]
                 LIMIT 5),
-    session:   (RECALL actions
+    session:   (RECALL tools
                 WHERE session_id = "sess-20260303-priya"
                 LIMIT 10)
   BUDGET 4000 tokens
@@ -166,7 +166,7 @@ SML is **not XML**. It requires no parser, no schema, no escape sequences. An LL
 
 ### Structural Rules
 
-1. **Tag names are grain types.** `<fact>`, `<goal>`, `<event>`, `<action>`, `<observation>`, `<reasoning>`, `<state>`, `<workflow>`, `<consensus>`, `<consent>` — no others.
+1. **Tag names are grain types.** `<fact>`, `<goal>`, `<event>`, `<tool>`, `<observation>`, `<reasoning>`, `<state>`, `<workflow>`, `<consensus>`, `<consent>` — no others.
 2. **Flat only.** No nesting beyond the `<context>` envelope.
 3. **No storage internals.** No hashes, namespaces, or OMS metadata in the output.
 4. **Natural language content.** Element text is prose, not decomposed triples.
@@ -190,8 +190,8 @@ This is the SML block injected into the LLM system prompt for the billing disput
 
   <workflow trigger="billing_dispute_opened" state="open">verify_charge -> check_renewal_date -> explain_or_escalate -> offer_billing_cycle_change -> close_ticket</workflow>
 
-  <action tool="get_invoice"    phase="completed">retrieved invoice INV-2026-02-28: $299 annual Professional plan renewal</action>
-  <action tool="get_plan_history" phase="completed">plan enrolled 2024-03-01, renewed annually; last renewal 2026-02-28</action>
+  <tool tool="get_invoice"    phase="completed">retrieved invoice INV-2026-02-28: $299 annual Professional plan renewal</tool>
+  <tool tool="get_plan_history" phase="completed">plan enrolled 2024-03-01, renewed annually; last renewal 2026-02-28</tool>
 
   <observation observer="billing-system">renewal processed automatically on 2026-02-28 at 00:01 UTC; no failed payment</observation>
   <observation observer="system">customer last viewed billing page 2026-01-15</observation>

--- a/SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md
+++ b/SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md
@@ -1,7 +1,7 @@
 # SML (Semantic Markup Language) Specification v1.0
 
 **Status:** Standards Track | **Date:** 2026-03-03 | **Version:** 1.0 | **Classification:** Experimental
-**Part of:** [Open Memory Specification (OMS) v1.3](./SPECIFICATION.md)
+**Part of:** [Open Memory Specification (OMS) v1.4](./SPECIFICATION.md)
 
 ---
 
@@ -22,7 +22,7 @@
 
 SML uses tag syntax as a **semantic signalling device** — the tag name tells the LLM what kind of information follows (using OMS grain types as tag names), the attributes carry lightweight decision metadata, and the element text is natural language content.
 
-SML is part of the [Open Memory Specification (OMS) v1.3](./SPECIFICATION.md) family. The `FORMAT` system that produces SML output is defined in the [Context Assembly Language (CAL) specification](./CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md).
+SML is part of the [Open Memory Specification (OMS) v1.4](./SPECIFICATION.md) family. The `FORMAT` system that produces SML output is defined in the [Context Assembly Language (CAL) specification](./CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md).
 
 ---
 
@@ -32,7 +32,7 @@ SML is part of the [Open Memory Specification (OMS) v1.3](./SPECIFICATION.md) fa
 
 | Property | SML | Standard XML |
 |----------|-----|--------------|
-| Tag names | Grain type identifiers (`belief`, `goal`, `event`, …) | Arbitrary element names |
+| Tag names | Grain type identifiers (`fact`, `goal`, `event`, …) | Arbitrary element names |
 | Text content | Natural language prose, not decomposed triples | Structured data |
 | Attributes | Human-readable metadata hints (`confidence`, `state`, `time`) | Machine-parseable key-value pairs |
 | Nesting | **Flat only** — no nested elements (one `<context>` envelope only) | Arbitrary depth |
@@ -49,8 +49,8 @@ SML is the default format for the `structured` preset (alias `sml`) in CAL's [FO
 
 The formatted output uses a **flat, semantic structure**:
 
-1. **Tag names ARE the grain type.** No generic `<grain>` wrapper — use `<belief>`, `<goal>`, `<event>`, etc.
-2. **No group wrappers.** No `<source>`, `<beliefs>`, or other container elements. Whitespace separates grain groups.
+1. **Tag names ARE the grain type.** No generic `<grain>` wrapper — use `<fact>`, `<goal>`, `<event>`, etc.
+2. **No group wrappers.** No `<source>`, `<facts>`, or other container elements. Whitespace separates grain groups.
 3. **Storage internals never appear.** No hashes, counts, namespaces, or OMS-internal fields.
 4. **Text content reads as natural language.** The element text is the projected content, not decomposed triples.
 5. **One envelope element.** The `<context>` wrapper carries only the `intent` attribute. It is the sole container.
@@ -64,9 +64,9 @@ The following example shows a single assembled context covering every grain type
 ```sml
 <context intent="helping alice prepare her Q1 engineering review">
 
-  <belief subject="alice" confidence="0.95">prefers dark mode in all tools</belief>
-  <belief subject="alice" confidence="0.88">requires keyboard shortcuts for productivity</belief>
-  <belief subject="alice" confidence="0.82">works best in deep-focus blocks of 90 minutes</belief>
+  <fact subject="alice" confidence="0.95">prefers dark mode in all tools</fact>
+  <fact subject="alice" confidence="0.88">requires keyboard shortcuts for productivity</fact>
+  <fact subject="alice" confidence="0.82">works best in deep-focus blocks of 90 minutes</fact>
 
   <goal subject="alice" state="active" deadline="2026-03-15">complete Q1 engineering review presentation</goal>
   <goal subject="alice" state="active">reduce P0 incident rate by 20% in Q2</goal>
@@ -75,8 +75,8 @@ The following example shows a single assembled context covering every grain type
   <event role="assistant" time="10m ago">Sure — retrieving deployment counts, incident data, and velocity now.</event>
   <event role="user" time="8m ago">Focus on the reliability numbers first.</event>
 
-  <action tool="query_metrics" phase="completed">retrieved 47 deployments and 3 P0 incidents for Q1 2026</action>
-  <action tool="search_docs" phase="completed">found Q1 review template in confluence/engineering/reviews</action>
+  <tool tool="query_metrics" phase="completed">retrieved 47 deployments and 3 P0 incidents for Q1 2026</tool>
+  <tool tool="search_docs" phase="completed">found Q1 review template in confluence/engineering/reviews</tool>
 
   <observation observer="system">alice opened incident-dashboard at 09:14 UTC</observation>
   <observation observer="system" source="calendar">Q1 review presentation scheduled for 2026-03-15 14:00 UTC</observation>
@@ -95,7 +95,7 @@ The following example shows a single assembled context covering every grain type
 </context>
 ```
 
-Each element maps directly to one grain type. The LLM reads the tag to understand the epistemic status of the content — a `<belief>` carries a known confidence, a `<reasoning>` signals inference, a `<consent>` signals an explicit permission grant — without needing to parse attribute schemas or understand OMS internals.
+Each element maps directly to one grain type. The LLM reads the tag to understand the epistemic status of the content — a `<fact>` carries a known confidence, a `<reasoning>` signals inference, a `<consent>` signals an explicit permission grant — without needing to parse attribute schemas or understand OMS internals.
 
 ---
 
@@ -105,9 +105,9 @@ Progressive disclosure controls **metadata density on a flat structure**, not ne
 
 | Level | Example |
 |-------|---------|
-| `summary` | `<belief subject="alice">prefers dark mode</belief>` |
-| `standard` | `<belief subject="alice" confidence="0.92">prefers dark mode</belief>` |
-| `full` | `<belief subject="alice" confidence="0.92" source="explicit" observed="2d ago">prefers dark mode</belief>` |
+| `summary` | `<fact subject="alice">prefers dark mode</fact>` |
+| `standard` | `<fact subject="alice" confidence="0.92">prefers dark mode</fact>` |
+| `full` | `<fact subject="alice" confidence="0.92" source="explicit" observed="2d ago">prefers dark mode</fact>` |
 
 ---
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -144,7 +144,7 @@ OMS defines the wire format and grain semantics. Two companion specifications ar
 
 CAL is a non-destructive, deterministic, LLM-native language for assembling agent context from OMS memory stores. It answers the question: *"what should be in the agent's context window right now?"* Key properties:
 
-- Operates on all 10 OMS grain types (Belief, Event, State, Workflow, Action, Observation, Goal, Reasoning, Consensus, Consent)
+- Operates on all 10 OMS grain types (Fact, Event, State, Workflow, Action, Observation, Goal, Reasoning, Consensus, Consent)
 - Extends the OMS Store Protocol (§28.4) with a formal, structured query syntax
 - `ASSEMBLE` statements compose context from multiple grain sources within a token budget
 - Append-only: CAL writes create new grains via `put`; the language cannot delete or modify existing grains — this is enforced at the grammar level
@@ -152,7 +152,7 @@ CAL is a non-destructive, deterministic, LLM-native language for assembling agen
 
 **SML — Semantic Markup Language** ([SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md](./SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md))
 
-SML is a flat, tag-based markup format optimized for LLM context consumption. It is not XML. Tag names are OMS grain types (`<belief>`, `<goal>`, `<event>`, …); attributes carry lightweight decision metadata; text content is natural language. SML is the default output format for CAL `ASSEMBLE` statements and is designed to be consumed directly by an LLM without an XML processor.
+SML is a flat, tag-based markup format optimized for LLM context consumption. It is not XML. Tag names are OMS grain types (`<fact>`, `<goal>`, `<event>`, …); attributes carry lightweight decision metadata; text content is natural language. SML is the default output format for CAL `ASSEMBLE` statements and is designed to be consumed directly by an LLM without an XML processor.
 
 ---
 
@@ -197,11 +197,11 @@ Hexadecimal values are lowercase. Byte sequences are represented in hex with spa
 
 | Value | Type | Description |
 |-------|------|-------------|
-| 0x01 | **Belief** | Structured belief — (subject, relation, object) triple with confidence and source |
+| 0x01 | **Fact** | Structured fact — (subject, relation, object) triple with confidence and source |
 | 0x02 | **Event** | Timestamped occurrence — message, interaction, or behavioral event |
 | 0x03 | **State** | Agent state snapshot — portable save point |
 | 0x04 | **Workflow** | Directed graph of procedural steps — plans, pipelines, processes |
-| 0x05 | **Action** | Tool invocation or code execution |
+| 0x05 | **Tool** | Tool invocation or code execution |
 | 0x06 | **Observation** | Raw sensory or cognitive input |
 | 0x07 | **Goal** | Objective with lifecycle semantics |
 | 0x08 | **Reasoning** | Inference chain and thought audit trail |
@@ -480,7 +480,7 @@ To minimize blob size, human-readable field names are mapped to short keys befor
 | Full Name | Short Key | Type | Notes |
 |-----------|-----------|------|-------|
 | `content` | `content` | string | Raw text of the event. MAY be omitted if `content_blocks` is present. |
-| `consolidated` | `consolidated` | bool | Whether this event has been distilled into Belief grains |
+| `consolidated` | `consolidated` | bool | Whether this event has been distilled into Fact grains |
 | `content_blocks` | `cblocks` | array[map] | Typed content blocks for structured LLM messages. When present, takes precedence over flat `content` string. Each entry: `{type: "text"/"image"/"tool_use"/"tool_result"/"thinking", ...}`. See note below. |
 | `model_id` | `mdl` | string | LLM model identifier that produced the response (e.g., `"claude-opus-4-6"`, `"gpt-4o"`). Absent for human-authored events. |
 | `stop_reason` | `stopr` | string | Why LLM generation stopped: `"end_turn"`, `"max_tokens"`, `"stop_sequence"`, `"tool_use"`. Open enum. |
@@ -533,7 +533,7 @@ To minimize blob size, human-readable field names are mapped to short keys befor
 | `stdout` | `out` | string | Standard output from code execution |
 | `stderr` | `err2` | string | Standard error from code execution |
 | `exit_code` | `xc` | int | Process exit code from code execution |
-| `interpreter_id` | `iid` | string | Links Action grains sharing a stateful interpreter session |
+| `interpreter_id` | `iid` | string | Links Tool grains sharing a stateful interpreter session |
 | `error` | `err` | string | Error message (use with `is_error: true`) |
 | `error_type` | `etype` | string | Structured error classification: `"timeout"`, `"rate_limit"`, `"auth_failure"`, `"invalid_input"`, `"server_error"`, `"not_found"`, `"quota_exceeded"`. Open enum. Enables retry policy decisions without parsing free-text `error`. |
 | `duration_ms` | `dur` | int | Execution time in milliseconds |
@@ -624,12 +624,12 @@ To minimize blob size, human-readable field names are mapped to short keys befor
 
 ### 6.11 Delegation-Specific Fields
 
-When a Goal or Belief grain uses the `mg:delegates_to` relation, the following fields specify the scope and constraints of the delegation. Without these fields, a delegation is unbounded — the delegatee receives no machine-readable limits. Implementations SHOULD populate delegation scope fields for any inter-agent authority grant.
+When a Goal or Fact grain uses the `mg:delegates_to` relation, the following fields specify the scope and constraints of the delegation. Without these fields, a delegation is unbounded — the delegatee receives no machine-readable limits. Implementations SHOULD populate delegation scope fields for any inter-agent authority grant.
 
 | Full Name | Short Key | Type | Notes |
 |-----------|-----------|------|-------|
 | `authorized_namespaces` | `ans` | array[string] | Namespaces the delegatee may read and write. `["*"]` = all namespaces (dangerous — SHOULD be avoided). |
-| `authorized_types` | `atypes` | array[uint8] | Grain type bytes the delegatee may create. E.g., `[0x01, 0x02, 0x05]` for Belief, Event, Action. |
+| `authorized_types` | `atypes` | array[uint8] | Grain type bytes the delegatee may create. E.g., `[0x01, 0x02, 0x05]` for Fact, Event, Tool. |
 | `authorized_tools` | `atools` | array[string] | Tool names the delegatee may invoke. Empty array = no tool restriction. |
 | `delegation_depth` | `ddepth` | int | Maximum re-delegation depth. 0 = delegatee MUST NOT re-delegate. Absent = unlimited (NOT RECOMMENDED). |
 | `delegation_expiry` | `dexp` | int64 | Epoch ms when delegation expires. After expiry, the delegatee's writes SHOULD be rejected by stores that enforce delegation scope. |
@@ -736,9 +736,9 @@ The `mg:` namespace is reserved for standard semantic relations. Applications de
 | Relation | Typical grain type | Meaning |
 |---|---|---|
 | `mg:perceives` | Observation | Raw sensory or cognitive input |
-| `mg:knows` | Belief | Derived belief or learned fact |
+| `mg:knows` | Fact | Derived fact or learned fact |
 | `mg:said` | Event | Message or utterance |
-| `mg:did` | Action | Tool or action invocation |
+| `mg:did` | Tool | Tool or action invocation |
 | `mg:infers` | Reasoning | Derived conclusion from prior grains |
 | `mg:agrees_with` | Consensus | Multi-agent threshold agreement |
 | `mg:state_at` | State | Agent state snapshot |
@@ -746,24 +746,24 @@ The `mg:` namespace is reserved for standard semantic relations. Applications de
 | `mg:intends` | Goal | Agent objective |
 | `mg:permits` | Consent | User grants agent right to retain or act |
 | `mg:revokes` | Consent | User revokes prior consent |
-| `mg:prohibits` | Belief/Goal | Hard prohibition |
-| `mg:requires` | Belief/Goal | Hard requirement |
-| `mg:prefers` | Belief | Soft preference |
-| `mg:avoids` | Belief | Soft avoidance preference |
+| `mg:prohibits` | Fact/Goal | Hard prohibition |
+| `mg:requires` | Fact/Goal | Hard requirement |
+| `mg:prefers` | Fact | Soft preference |
+| `mg:avoids` | Fact | Soft avoidance preference |
 | `mg:delegates_to` | Goal | Scoped authority grant (§6.11 delegation scope) |
-| `mg:owned_by` | Belief | Legal entity ownership (§12.5) |
-| `mg:has_capability` | Belief | Agent capability advertisement (§28.5 Agent Card) |
+| `mg:owned_by` | Fact | Legal entity ownership (§12.5) |
+| `mg:has_capability` | Fact | Agent capability advertisement (§28.5 Agent Card) |
 | `mg:handed_off_to` | Event | Session handoff event record (§28.7) |
 | `mg:depends_on` | Goal | Task dependency (distinct from `parent_goals` hierarchy) |
 | `mg:assigned_to` | Goal | Task assigned to agent for execution |
-| `mg:capable_of` | Belief | Learned skill with proficiency and strategies (§28.8 Skill Convention) |
+| `mg:capable_of` | Fact | Learned skill with proficiency and strategies (§28.8 Skill Convention) |
 
-### 8.1 Belief (type = 0x01)
+### 8.1 Fact (type = 0x01)
 
-A structured belief about the world — a (subject, relation, object) triple with confidence and source. The canonical unit of declarative knowledge.
+A structured fact about the world — a (subject, relation, object) triple with confidence and source. The canonical unit of declarative knowledge.
 
 **Required fields:**
-- `type` = "belief" (payload string; header byte = `0x01`)
+- `type` = "fact" (payload string; header byte = `0x01`)
 - `subject` (non-empty string)
 - `relation` (non-empty string)
 - `object` (string or map)
@@ -844,7 +844,7 @@ Directed graph of procedural steps — plans, pipelines, and multi-path processe
 | Named | No binding, but an Action definition grain exists with matching `tool_name` | Resolve by convention (implementation-defined lookup) |
 | Abstract | No binding, no matching tool | Node label is a human-readable instruction; executor (LLM or agent) interprets it |
 
-**Execution record relation:** When an agent executes a workflow node, it creates an Action grain (phase: complete or call/result) with a relation of type `mg:step_action:<node_id>` targeting the Workflow grain hash. This links execution records to the plan without modifying the immutable Workflow grain.
+**Execution record relation:** When an agent executes a workflow node, it creates an Tool grain (phase: complete or call/result) with a relation of type `mg:step_action:<node_id>` targeting the Workflow grain hash. This links execution records to the plan without modifying the immutable Workflow grain.
 
 **Example — linear pipeline:**
 
@@ -942,7 +942,7 @@ An explicit objective with lifecycle semantics. Goals transition through states 
 
 **Optional fields:** `criteria`, `criteria_structured`, `priority`, `parent_goals`, `depends_on` (array[string] — content addresses of prerequisite Goal grains that must complete before this one starts; distinct from `parent_goals` which implies decomposition, not dependency ordering), `assigned_agent` (string — DID of the agent assigned to execute this task), `expected_output` (string — description of expected output format), `output_grain` (string — content address of the grain containing the task's completed output), `deadline` (int64 — epoch ms hard deadline for task completion), `state_reason`, `satisfaction_evidence`, `progress`, `delegate_to`, `delegate_from`, `expiry_policy`, `recurrence`, `evidence_required`, `rollback_on_failure`, `allowed_transitions`, all common fields.
 
-Constraints, policies, and delegations are expressed as Goal or Belief grains with `mg:prohibits`, `mg:prefers`, `mg:avoids`, or `mg:delegates_to` relations, combined with `invalidation_policy` (§23) for enforcement.
+Constraints, policies, and delegations are expressed as Goal or Fact grains with `mg:prohibits`, `mg:prefers`, `mg:avoids`, or `mg:delegates_to` relations, combined with `invalidation_policy` (§23) for enforcement.
 
 > **Note — plan-and-execute agents:** The `depends_on` field enables DAG-structured task dependency graphs for hierarchical task decomposition. Agents using plan-and-execute patterns (e.g., LangGraph StateGraph, CrewAI task dependencies) SHOULD express task ordering via `depends_on` and task hierarchy via `parent_goals`. A Goal grain with `depends_on` references MUST NOT transition to `goal_state: "active"` until all referenced Goal grains have `goal_state: "satisfied"`. The `assigned_agent` field enables multi-agent task routing: the orchestrator creates Goal grains with `assigned_agent` pointing to worker agent DIDs.
 
@@ -987,7 +987,7 @@ A multi-agent agreement record — N observers voted on a shared claim, threshol
 
 ### 8.10 Consent (type = 0x0A)
 
-A DID-scoped, purpose-bounded permission grant or withdrawal. Four of six industry review domains independently required a dedicated Consent type at the type-byte level — HIPAA patient consent, legal privilege and DPA, regulatory consent, and GDPR/CCPA at scale. The `Belief + mg:permits` pattern is semantically correct but impractical when consent queries are compliance-critical and frequent.
+A DID-scoped, purpose-bounded permission grant or withdrawal. Four of six industry review domains independently required a dedicated Consent type at the type-byte level — HIPAA patient consent, legal privilege and DPA, regulatory consent, and GDPR/CCPA at scale. The `Fact + mg:permits` pattern is semantically correct but impractical when consent queries are compliance-critical and frequent.
 
 **Required fields:**
 - `type` = "consent"
@@ -1386,11 +1386,11 @@ For non-person memory (seasonal, device, system), `user_id` is simply omitted. `
 
 ### 12.5 Agent Ownership and Legal Entity
 
-An agent may belong to a legal entity — a natural person or a juridical person (company, partnership, NGO, government body). OMS expresses this relationship as a protected Belief grain written at agent provisioning time by the operator, not by the agent itself.
+An agent may belong to a legal entity — a natural person or a juridical person (company, partnership, NGO, government body). OMS expresses this relationship as a protected Fact grain written at agent provisioning time by the operator, not by the agent itself.
 
 #### 12.5.1 The `owner` Field
 
-Any grain type MAY carry an `owner` field (compacted: `own`) containing a **LegalEntity** map. In practice, `owner` is used in the ownership Belief grain described in §12.5.3. It MUST NOT be used as an access control gate — `invalidation_policy` (§23) governs supersession authorization.
+Any grain type MAY carry an `owner` field (compacted: `own`) containing a **LegalEntity** map. In practice, `owner` is used in the ownership Fact grain described in §12.5.3. It MUST NOT be used as an access control gate — `invalidation_policy` (§23) governs supersession authorization.
 
 **LegalEntity sub-schema:**
 
@@ -1441,9 +1441,9 @@ This is an open enum. Implementations MAY define additional values for jurisdict
 
 Prefixes not listed here MUST be preserved as-is. New prefixes do not require a spec update.
 
-#### 12.5.3 Ownership Belief Grain Convention
+#### 12.5.3 Ownership Fact Grain Convention
 
-Agent ownership is expressed as a Belief grain with `relation: "mg:owned_by"` in the `"agent:identity"` namespace. The `object` field carries the owner's legal name as a string (for semantic triple completeness). The structured `owner` field carries the full LegalEntity map.
+Agent ownership is expressed as a Fact grain with `relation: "mg:owned_by"` in the `"agent:identity"` namespace. The `object` field carries the owner's legal name as a string (for semantic triple completeness). The structured `owner` field carries the full LegalEntity map.
 
 This grain MUST be written by the operator at agent provisioning time. It MUST carry an `invalidation_policy` (§23) restricting supersession to the owner's authorized DID. It SHOULD be COSE-signed (§9) by the owner's DID.
 
@@ -1451,7 +1451,7 @@ This grain MUST be written by the operator at agent provisioning time. It MUST c
 
 ```json
 {
-  "type": "belief",
+  "type": "fact",
   "subject": "did:web:example.com:agents:my-agent",
   "relation": "mg:owned_by",
   "object": "Example Corp Pvt. Ltd.",
@@ -1481,7 +1481,7 @@ This grain MUST be written by the operator at agent provisioning time. It MUST c
 
 ```json
 {
-  "type": "belief",
+  "type": "fact",
   "subject": "did:key:z6MkAgentDID...",
   "relation": "mg:owned_by",
   "object": "Jane Doe",
@@ -1525,7 +1525,7 @@ This grain MUST be written by the operator at agent provisioning time. It MUST c
 1. The ownership grain MUST NOT be authored by the agent's own DID. Only the operator's DID is authorized to write it (key separation, §23.8).
 2. The `subject` MUST be the agent's DID.
 3. When multiple grains with `relation: "owned_by"` exist for the same `subject` in the `"agent:identity"` namespace, the grain with `invalidation_policy.mode ≠ "open"` is authoritative. Stores SHOULD surface it as the canonical ownership record.
-4. An agent observing a user assertion that contradicts the locked ownership grain MAY record that claim as an Observation grain. It MUST NOT write a superseding ownership Belief without the authorized signature.
+4. An agent observing a user assertion that contradicts the locked ownership grain MAY record that claim as an Observation grain. It MUST NOT write a superseding ownership Fact without the authorized signature.
 
 #### 12.5.4 Protection Layers
 
@@ -1796,7 +1796,7 @@ All Level 2 requirements, plus:
 - Hash-chained audit trail
 - Crash recovery and reconciliation
 - Policy engine with compliance presets
-- SHOULD partition Observation grain storage by observer domain, inferred from `observer_type`. Physical observer types (see Section 24) SHOULD flow to time-series storage with raw-data retention policies. Cognitive observer types SHOULD flow to vector + relational storage with the same retrieval semantics as Belief grains. Implementations MUST NOT hard-code the domain partition list — treat `observer_type` as an open string and drive routing from configuration or namespace.
+- SHOULD partition Observation grain storage by observer domain, inferred from `observer_type`. Physical observer types (see Section 24) SHOULD flow to time-series storage with raw-data retention policies. Cognitive observer types SHOULD flow to vector + relational storage with the same retrieval semantics as Fact grains. Implementations MUST NOT hard-code the domain partition list — treat `observer_type` as an open string and drive routing from configuration or namespace.
 
 ---
 
@@ -1977,7 +1977,7 @@ cb 3f ec cc cc cc cc cc cd a2 63 61 cf 00 00 01 9b c1 19 01 00 a2 6e 73 a6
 69 74 a1 74 a4 66 61 63 74
 ```
 
-> Header breakdown: `01`=version, `00`=flags (public, MessagePack, unsigned), `01`=Belief type, `a4 d2`=SHA-256("shared")[0:2] as uint16 big-endian, `69 68 ba a0`=created_at_sec (1768471200 = 2026-01-15T10:00:00Z, big-endian).
+> Header breakdown: `01`=version, `00`=flags (public, MessagePack, unsigned), `01`=Fact type, `a4 d2`=SHA-256("shared")[0:2] as uint16 big-endian, `69 68 ba a0`=created_at_sec (1768471200 = 2026-01-15T10:00:00Z, big-endian).
 >
 > Payload breakdown: `89`=fixmap(9), `a4 61 64 69 64`=key "adid" (fixstr 4), `d9 38`=str8 length 56, followed by 56 UTF-8 bytes of the DID; key `c` value: `cb 3f ec cc cc cc cc cc cd` (float64 marker + 8 bytes = `3feccccccccccccd` = 0.9); then remaining keys "ca"/"ns"/"o"/"r"/"s"/"st"/"t" in lexicographic order with their values.
 
@@ -2000,12 +2000,12 @@ cb 3f ec cc cc cc cc cc cd a2 63 61 cf 00 00 01 9b c1 19 01 00 a2 6e 73 a6
 [computed by reference implementation]
 ```
 
-### 21.3 Vector 3: Bi-Temporal Belief
+### 21.3 Vector 3: Bi-Temporal Fact
 
 **Input:**
 ```json
 {
-  "type": "belief",
+  "type": "fact",
   "subject": "Alice",
   "relation": "works_at",
   "object": "Acme Corp",
@@ -2024,12 +2024,12 @@ cb 3f ec cc cc cc cc cc cd a2 63 61 cf 00 00 01 9b c1 19 01 00 a2 6e 73 a6
 [computed by reference implementation]
 ```
 
-### 21.4 Vector 4: Belief with Cross-Links
+### 21.4 Vector 4: Fact with Cross-Links
 
 **Input:**
 ```json
 {
-  "type": "belief",
+  "type": "fact",
   "subject": "Bob",
   "relation": "manages",
   "object": "Project Alpha",
@@ -2179,7 +2179,7 @@ To verify conformance:
 
 ### 22.7 Streaming and Partial Results
 
-OMS grains are atomic, immutable knowledge units. Streaming outputs (e.g., token-by-token LLM responses, incremental tool results, partial server-sent events) are transport-layer concerns outside OMS scope. Implementations SHOULD buffer streaming content in their transport layer and emit a single immutable Event or Action grain upon stream completion. For long-running tool executions requiring progress visibility, implementations MAY emit periodic State grains (type 0x03) as progress checkpoints, linked via `derived_from` to the originating Action grain. Each checkpoint is a complete, self-contained grain — not a diff.
+OMS grains are atomic, immutable knowledge units. Streaming outputs (e.g., token-by-token LLM responses, incremental tool results, partial server-sent events) are transport-layer concerns outside OMS scope. Implementations SHOULD buffer streaming content in their transport layer and emit a single immutable Event or Tool grain upon stream completion. For long-running tool executions requiring progress visibility, implementations MAY emit periodic State grains (type 0x03) as progress checkpoints, linked via `derived_from` to the originating Tool grain. Each checkpoint is a complete, self-contained grain — not a diff.
 
 ### 22.8 Recall Priority and Agent Memory Tiers
 
@@ -2201,10 +2201,10 @@ For cross-framework agent state portability, implementations SHOULD use the foll
 |---|---|---|
 | `messages_tail` | string | Content address of the most recent Event grain in the conversation |
 | `memory_blocks` | map | Named memory blocks: `{block_name: block_value_string}`. Letta-compatible. |
-| `system_prompt` | string | System prompt text, or content address of a Belief grain containing it |
+| `system_prompt` | string | System prompt text, or content address of a Fact grain containing it |
 | `active_tools` | array[string] | Tool names available in this agent state |
 | `model` | string | LLM model identifier (e.g., `"claude-opus-4-6"`) |
-| `pending_tool_calls` | array[string] | Content addresses of Action grains in `"call"` phase awaiting results |
+| `pending_tool_calls` | array[string] | Content addresses of Tool grains in `"call"` phase awaiting results |
 | `agent_config` | map | Framework-specific agent configuration (opaque to the spec) |
 
 This schema is RECOMMENDED, not required. Implementations MAY include additional keys. The `memory_blocks` key is aligned with Letta's `core_memory` structure. The `messages_tail` key enables reconstructing the conversation by following `parent_message_id` chains backward from the tail.
@@ -2445,7 +2445,7 @@ The `observation_scope` field is a **closed enum**. It describes the temporal br
 
 ## 27. Grain Type Field Specifications
 
-This section provides detailed field specifications for each standard grain type. For Action grain phase fields, see §27.1. For Observer types, see §24. For Observation modes/scopes, see §25/§26.
+This section provides detailed field specifications for each standard grain type. For Tool grain phase fields, see §27.1. For Observer types, see §24. For Observation modes/scopes, see §25/§26.
 
 ### 27.1 Action Grain (type = 0x05) — Phase and Mode Details
 
@@ -2578,7 +2578,7 @@ The `action_phase` field acts as a discriminator for async vs. synchronous tool 
 | `"goal_decomposition"` | Agent decomposed a parent goal |
 | `"goal_state_transition"` | Updates state of a prior Goal grain |
 | `"goal_revision"` | Human modified a previously set goal |
-| `"goal_inference"` | Agent inferred from Event or Belief patterns |
+| `"goal_inference"` | Agent inferred from Event or Fact patterns |
 | `"goal_delegation"` | Delegated from another agent |
 
 ### 27.3 `source_type` Registry
@@ -2846,12 +2846,12 @@ Stores SHOULD implement `supersede` as a distinct operation rather than exposing
 
 ### 28.5 Agent Capability Convention
 
-Agents that participate in multi-agent systems SHOULD advertise their capabilities by writing a Belief grain with the `mg:has_capability` relation to the `"agent:identity"` namespace. This grain serves as the OMS equivalent of an A2A Agent Card or MCP server capability declaration.
+Agents that participate in multi-agent systems SHOULD advertise their capabilities by writing a Fact grain with the `mg:has_capability` relation to the `"agent:identity"` namespace. This grain serves as the OMS equivalent of an A2A Agent Card or MCP server capability declaration.
 
 **Convention:**
 ```json
 {
-  "type": "belief",
+  "type": "fact",
   "subject": "did:web:example.com:agents:summarizer",
   "relation": "mg:has_capability",
   "object": {
@@ -2887,7 +2887,7 @@ The `object` map is an open schema. Standard keys:
 | `max_context_tokens` | int | Maximum context window in tokens |
 | `model` | string | Underlying LLM model identifier |
 
-Agents can discover other agents by querying Belief grains with `relation: "mg:has_capability"` in the `"agent:identity"` namespace.
+Agents can discover other agents by querying Fact grains with `relation: "mg:has_capability"` in the `"agent:identity"` namespace.
 
 ### 28.6 Conversation Threading Convention
 
@@ -2897,7 +2897,7 @@ Conversations are reconstructed from Event grain sequences using `session_id` an
 2. Event grains SHOULD populate `parent_message_id` (§6.2) to form a linked list from newest to oldest.
 3. Branch points are expressed by two Event grains sharing the same `parent_message_id` but having different content addresses (tree-of-thought, beam search, alternative paths).
 4. A State grain (type 0x03) with `relation: "mg:state_at"` and a `context` map containing `{messages_tail, message_count, participants}` represents a conversation snapshot.
-5. Conversation summaries are Belief grains with `consolidation_level >= 1`, `derived_from` pointing to the summarized Event grains, and `source_type: "consolidated"`.
+5. Conversation summaries are Fact grains with `consolidation_level >= 1`, `derived_from` pointing to the summarized Event grains, and `source_type: "consolidated"`.
 
 **Retrieving a conversation:**
 1. Query: `type=event, session_id=X, system_valid_to=null, sort=timestamp_ms ASC`
@@ -2908,26 +2908,26 @@ Conversations are reconstructed from Event grain sequences using `session_id` an
 When Agent A transfers control of a conversation to Agent B, the handoff is recorded using a Goal grain with `mg:delegates_to` relation and delegation scope fields (§6.11):
 
 1. Agent A writes a Goal grain with `relation: "mg:delegates_to"`, `subject` = Agent A's DID, `object` = Agent B's DID, and delegation scope fields specifying `authorized_namespaces`, `authorized_tools`, `context_grains`, and `return_to`.
-2. The `context_grains` field contains content addresses of grains Agent B needs to continue — typically the recent Event grain chain and any relevant Belief/State grains.
+2. The `context_grains` field contains content addresses of grains Agent B needs to continue — typically the recent Event grain chain and any relevant Fact/State grains.
 3. Agent B ingests the referenced grains, validates the delegation scope, and continues with a new `run_id` but the same `session_id`.
 4. When Agent B completes its task, it writes a Goal grain with `goal_state: "satisfied"` linked via `derived_from` to the delegation grain, and control returns to the agent specified in `return_to`.
 
 ### 28.8 Skill Convention
 
-Agents that learn reusable capabilities SHOULD represent them as Belief grains with `relation: "mg:capable_of"` and a structured `object` map. A skill grain captures what an agent can do, how well it can do it, and the procedural knowledge needed to transfer the capability to another agent.
+Agents that learn reusable capabilities SHOULD represent them as Fact grains with `relation: "mg:capable_of"` and a structured `object` map. A skill grain captures what an agent can do, how well it can do it, and the procedural knowledge needed to transfer the capability to another agent.
 
 **Distinction from related constructs:**
 
 | Construct | Grain type | What it captures |
 |---|---|---|
-| Agent Capability (§28.5) | Belief (`mg:has_capability`) | Static identity card — what the agent *is built to do* |
-| Skill (§28.8) | Belief (`mg:capable_of`) | Learned capability — what the agent *has learned to do*, with proficiency and strategies |
+| Agent Capability (§28.5) | Fact (`mg:has_capability`) | Static identity card — what the agent *is built to do* |
+| Skill (§28.8) | Fact (`mg:capable_of`) | Learned capability — what the agent *has learned to do*, with proficiency and strategies |
 | Workflow (§8.4) | Workflow | Fixed action sequence — a single procedure, not an adaptive capability |
 
 **Convention:**
 ```json
 {
-  "type": "belief",
+  "type": "fact",
   "subject": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
   "relation": "mg:capable_of",
   "object": {
@@ -2970,7 +2970,7 @@ The `object` map is an open schema. Standard keys:
 | `description` | string | Human-readable summary of what the skill enables |
 | `proficiency` | float64, [0.0, 1.0] | Current mastery level. SHOULD equal the grain's top-level `confidence`. |
 | `strategies` | array[map] | Context-dependent approaches. Each entry: `{condition: string, workflow: string, description?: string}`. The `workflow` value is a content address of a Workflow grain (§8.4). |
-| `prerequisites` | array[string] | Content addresses of Skill Belief grains that must be acquired before this skill is effective |
+| `prerequisites` | array[string] | Content addresses of Skill Fact grains that must be acquired before this skill is effective |
 | `practice_count` | int | Number of successful applications (mirrors `success_count` in core fields) |
 | `last_practiced_at` | int64 | Epoch ms of most recent successful application |
 | `transferable` | bool | If `true`, another agent MAY ingest this grain and its referenced Workflow grains to acquire the skill |
@@ -2978,26 +2978,26 @@ The `object` map is an open schema. Standard keys:
 | `output_modalities` | array[string] | What the skill produces |
 | `domain` | string | Domain context: `"software"`, `"research"`, `"healthcare"`, `"finance"`. Open enum. |
 
-**Namespace:** Skill Belief grains SHOULD use the `"agent:skills"` namespace to enable efficient discovery queries.
+**Namespace:** Skill Fact grains SHOULD use the `"agent:skills"` namespace to enable efficient discovery queries.
 
 **Proficiency lifecycle:**
 
-1. **Acquisition.** When an agent first learns a capability, it writes a Skill Belief grain with an initial `proficiency` (typically low). The `derived_from` field SHOULD reference the grains (Events, Actions, Reasoning) that contributed to learning.
-2. **Improvement.** Each time proficiency changes, the agent supersedes the previous Skill Belief grain with an updated `proficiency` and incremented `practice_count`. The supersession chain provides a full learning history.
+1. **Acquisition.** When an agent first learns a capability, it writes a Skill Fact grain with an initial `proficiency` (typically low). The `derived_from` field SHOULD reference the grains (Events, Actions, Reasoning) that contributed to learning.
+2. **Improvement.** Each time proficiency changes, the agent supersedes the previous Skill Fact grain with an updated `proficiency` and incremented `practice_count`. The supersession chain provides a full learning history.
 3. **Degradation.** Implementations MAY decay proficiency over time if `last_practiced_at` exceeds a threshold. This is an index-layer concern, not a grain mutation — the store writes a new superseding grain with reduced proficiency.
 
 **Skill transfer between agents:**
 
-1. Agent A queries its store: `type=belief, relation="mg:capable_of", namespace="agent:skills", transferable=true`.
-2. Agent A shares the Skill Belief grain and all Workflow grains referenced in `strategies` with Agent B (via `get_batch` on the content addresses).
-3. Agent B ingests the grains, rewrites the Skill Belief with its own `author_did`, initial `proficiency: 0.0`, and `practice_count: 0`, and sets `derived_from` to Agent A's original Skill Belief content address. The `origin_did` field preserves Agent A's DID for provenance.
+1. Agent A queries its store: `type=fact, relation="mg:capable_of", namespace="agent:skills", transferable=true`.
+2. Agent A shares the Skill Fact grain and all Workflow grains referenced in `strategies` with Agent B (via `get_batch` on the content addresses).
+3. Agent B ingests the grains, rewrites the Skill Fact with its own `author_did`, initial `proficiency: 0.0`, and `practice_count: 0`, and sets `derived_from` to Agent A's original Skill Fact content address. The `origin_did` field preserves Agent A's DID for provenance.
 4. Agent B improves proficiency through practice, superseding the skill grain as described above.
 
 **Skill discovery:**
 
-Agents discover available skills by querying: `type=belief, relation="mg:capable_of", namespace="agent:skills", system_valid_to=null, sort=proficiency DESC`.
+Agents discover available skills by querying: `type=fact, relation="mg:capable_of", namespace="agent:skills", system_valid_to=null, sort=proficiency DESC`.
 
-To find agents capable of a specific skill: `type=belief, relation="mg:capable_of", object.name="code_review", system_valid_to=null`.
+To find agents capable of a specific skill: `type=fact, relation="mg:capable_of", object.name="code_review", system_valid_to=null`.
 
 > **Note — promotion path:** If the convention approach proves insufficient — for instance, if skill queries become performance-critical across large multi-agent deployments, or if multiple domain profiles independently require skill-specific fields at the type level — a dedicated Skill grain type (`0x0B`) with its own required fields and type byte MAY be introduced in a future OMS version, following the precedent set by Consent (§8.10).
 
@@ -3020,7 +3020,7 @@ CAL extends the store operations defined in §28.4 with a structured query langu
 
 **SML output format:**
 
-CAL `ASSEMBLE` statements produce **SML (Semantic Markup Language)** output by default. SML is a flat, tag-based markup format optimized for LLM consumption: tag names are OMS grain types (`<belief>`, `<goal>`, `<event>`, …), attributes carry lightweight metadata, and text content is natural language. See the [SML specification](./SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md) for the full format definition, structural rules, and progressive disclosure model. Implementations that expose a query layer SHOULD support CAL and produce SML output for agent context assembly.
+CAL `ASSEMBLE` statements produce **SML (Semantic Markup Language)** output by default. SML is a flat, tag-based markup format optimized for LLM consumption: tag names are OMS grain types (`<fact>`, `<goal>`, `<event>`, …), attributes carry lightweight metadata, and text content is natural language. See the [SML specification](./SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md) for the full format definition, structural rules, and progressive disclosure model. Implementations that expose a query layer SHOULD support CAL and produce SML output for agent context assembly.
 
 ---
 
@@ -3264,7 +3264,7 @@ header-fields = flags-byte type-byte ns-hash-bytes created-at-bytes
                 ; version-byte + header-fields = 9-byte "fixed header" in §3.1
 flags-byte    = %x00-FF
 type-byte     = %x01-0A / %xF0-FF
-                ; Belief=0x01, Event=0x02, State=0x03, Workflow=0x04, Action=0x05,
+                ; Fact=0x01, Event=0x02, State=0x03, Workflow=0x04, Action=0x05,
                 ; Observation=0x06, Goal=0x07, Reasoning=0x08, Consensus=0x09,
                 ; Consent=0x0A, 0x0B-0xEF reserved, 0xF0-0xFF domain profile types
 ns-hash-bytes = 2OCTET  ; uint16 big-endian, first two bytes of SHA-256(namespace)
@@ -3586,11 +3586,11 @@ See [CHANGELOG.md](CHANGELOG.md) for the full version history.
 - **Provenance:** Derivation trail showing how grain was created
 - **Cross-link:** Semantic relationship between grains
 - **Bi-temporal:** Tracking both event-time and system-time dimensions
-- **Belief:** Grain type 0x01 — a held claim, factual statement, or declarative knowledge about the world
+- **Fact:** Grain type 0x01 — a held claim, factual statement, or declarative knowledge about the world
 - **Event:** Grain type 0x02 — a discrete occurrence with start/end time
 - **State:** Grain type 0x03 — a persisting condition or status at a point in time
 - **Workflow:** Grain type 0x04 — a directed graph of procedural steps, supporting sequential, conditional, parallel, and cyclic execution paths
-- **Action:** Grain type 0x05 — a completed tool invocation, API call, or agent action
+- **Tool:** Grain type 0x05 — a completed tool invocation, API call, or agent action
 - **Observation:** Grain type 0x06 — a raw sensor or environmental reading without interpretation
 - **Goal:** Grain type 0x07 — a desired future state or objective
 - **Reasoning:** Grain type 0x08 — an inference chain, chain-of-thought, or decision rationale
@@ -3608,9 +3608,9 @@ See [CHANGELOG.md](CHANGELOG.md) for the full version history.
 ## Appendix G: Complete Example Grain
 
 ```python
-# Create a belief grain
+# Create a fact grain
 grain = {
-    "type": "belief",
+    "type": "fact",
     "subject": "machine-learning",
     "relation": "is_subset_of",
     "object": "artificial-intelligence",
@@ -3644,7 +3644,7 @@ grain = {
 # 4. Sort keys lexicographically
 # 5. Encode as canonical MessagePack
 # 6. Prepend 9-byte fixed header: version(1) + flags(1) + type(1) + ns_hash(2) + created_at(4)
-#    type byte = 0x01 (Belief)
+#    type byte = 0x01 (Fact)
 # 7. Compute SHA-256 hash
 
 blob = serialize(grain)
@@ -3656,7 +3656,7 @@ content_address = sha256(blob).hex()
 
 ---
 
-**Document Status:** This is a v1.3 revision of the .mg format specification. This revision adds `output_schema` to the Action grain definition phase, introduces the Integration domain profile (`profile:integration`) for REST API connectors and tool catalogs, documents trigger definition conventions via Observation grains, and documents Consensus grain usage patterns for multi-source action definition validation. Submitted as a standards track document for consideration as an IETF RFC and W3C standard. Community feedback is encouraged through issue tracking and discussion forums.
+**Document Status:** This is a v1.3 revision of the .mg format specification. This revision adds `output_schema` to the Tool grain definition phase, introduces the Integration domain profile (`profile:integration`) for REST API connectors and tool catalogs, documents trigger definition conventions via Observation grains, and documents Consensus grain usage patterns for multi-source action definition validation. Submitted as a standards track document for consideration as an IETF RFC and W3C standard. Community feedback is encouraged through issue tracking and discussion forums.
 
 **Last Updated:** 2026-03-03
 **License:** This document is offered under the Open Web Foundation Final Specification Agreement (OWFa 1.0)

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1,10 +1,10 @@
 # Open Memory Specification (OMS)
 ## Memory Grain (.mg) Container Definition
 
-**Version:** 1.3
+**Version:** 1.4
 **Status:** Standards Track
 **Category:** Data Formats
-**Date:** February 2026
+**Date:** June 2026
 **Copyright:** Public Domain (CC0 1.0 Universal)
 **License:** This specification is offered under the Open Web Foundation Final Specification Agreement (OWFa 1.0)
 
@@ -68,7 +68,7 @@ A memory grain is the atomic unit of agent knowledge—a single immutable fact, 
 
 The .mg container format is to autonomous systems what JSON is to APIs and .git objects are to version control: a universal, language-agnostic, self-describing interchange format. It is the foundational wire format of OMS.
 
-**CAL (Context Assembly Language)** ([CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md](./CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md)) and **SML (Semantic Markup Language)** ([SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md](./SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md)) are part of OMS v1.3. CAL defines the query and context-assembly layer that operates on OMS stores; SML is CAL's default output format for LLM context consumption. See §1.5 for details.
+**CAL (Context Assembly Language)** ([CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md](./CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md)) and **SML (Semantic Markup Language)** ([SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md](./SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md)) are part of OMS v1.4. CAL defines the query and context-assembly layer that operates on OMS stores; SML is CAL's default output format for LLM context consumption. See §1.5 for details.
 
 ---
 
@@ -138,13 +138,13 @@ OMS addresses this gap by defining a universal standard for knowledge interchang
 
 ### 1.5 Companion Specifications
 
-OMS defines the wire format and grain semantics. Two companion specifications are part of the OMS v1.3 release and are included in this repository:
+OMS defines the wire format and grain semantics. Two companion specifications are part of the OMS v1.4 release and are included in this repository:
 
 **CAL — Context Assembly Language** ([CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md](./CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md))
 
 CAL is a non-destructive, deterministic, LLM-native language for assembling agent context from OMS memory stores. It answers the question: *"what should be in the agent's context window right now?"* Key properties:
 
-- Operates on all 10 OMS grain types (Fact, Event, State, Workflow, Action, Observation, Goal, Reasoning, Consensus, Consent)
+- Operates on all 10 OMS grain types (Fact, Event, State, Workflow, Tool, Observation, Goal, Reasoning, Consensus, Consent)
 - Extends the OMS Store Protocol (§28.4) with a formal, structured query syntax
 - `ASSEMBLE` statements compose context from multiple grain sources within a token budget
 - Append-only: CAL writes create new grains via `put`; the language cannot delete or modify existing grains — this is enforced at the grammar level
@@ -503,7 +503,7 @@ To minimize blob size, human-readable field names are mapped to short keys befor
 | `trigger` | `trigger` | string | Activation condition |
 | `nodes` | `nodes` | array[string] | Graph node IDs/labels |
 | `edges` | `edges` | array[map] | Directed edges (see §8.4 edge schema) |
-| `bindings` | `bind` | map[string→string] | Node ID → Action definition grain hash |
+| `bindings` | `bind` | map[string→string] | Node ID → Tool definition grain hash |
 | `retries` | `retries` | map[string→int] | Node ID → max repeat count |
 
 **Edge nested field compaction:**
@@ -515,11 +515,11 @@ To minimize blob size, human-readable field names are mapped to short keys befor
 | `cond` | `cond` | string |
 | `max_cycles` | `mxc` | int |
 
-### 6.5 Action-Specific Fields
+### 6.5 Tool-Specific Fields
 
 | Full Name | Short Key | Type | Notes |
 |-----------|-----------|------|-------|
-| `action_phase` | `aphase` | string | Discriminator: `"definition"` \| `"call"` \| `"result"` \| absent = complete |
+| `tool_phase` | `aphase` | string | Discriminator: `"definition"` \| `"call"` \| `"result"` \| absent = complete |
 | `tool_name` | `tn` | string | |
 | `input` | `inp` | map | Canonical name for tool arguments (replaces `arguments`) |
 | `content` | `cnt` | any | Canonical name for tool result (replaces `result`) |
@@ -540,7 +540,7 @@ To minimize blob size, human-readable field names are mapped to short keys befor
 | `parent_task_id` | `ptid` | string | Content address of parent task grain |
 | `tool_description` | `tdesc` | string | Human-readable description of the tool (definition phase) |
 | `input_schema` | `isch` | map | JSON Schema for tool inputs; mirrors Anthropic `input_schema` / MCP `inputSchema` (definition phase) |
-| `output_schema` | `osch` | map | JSON Schema (draft-07 compatible) describing the action's return value (definition phase) |
+| `output_schema` | `osch` | map | JSON Schema (draft-07 compatible) describing the tool's return value (definition phase) |
 | `strict` | `strict` | bool | If `true`, model guarantees strict JSON Schema conformance for `input` (definition phase) |
 
 ### 6.6 Observation-Specific Fields
@@ -808,7 +808,7 @@ Directed graph of procedural steps — plans, pipelines, and multi-path processe
 **Optional fields:**
 - `trigger` (string) — condition that activates this workflow
 - `edges` (array[map]) — directed edges between nodes (see edge schema below). When absent, nodes are unconnected.
-- `bindings` (map[string→string]) — maps node IDs to Action definition grain hashes (`action_phase: "definition"`). Unbound nodes are resolved by convention (tool name match) or treated as abstract steps.
+- `bindings` (map[string→string]) — maps node IDs to Tool definition grain hashes (`tool_phase: "definition"`). Unbound nodes are resolved by convention (tool name match) or treated as abstract steps.
 - `retries` (map[string→int]) — maps node IDs to maximum repeat count on failure. Absent means no retry.
 - All common fields.
 
@@ -836,15 +836,15 @@ Directed graph of procedural steps — plans, pipelines, and multi-path processe
 - Node IDs MUST be unique within `nodes`.
 - Unbounded cycles (back-edge without `max_cycles`, and no entry in `retries` for the target node) SHOULD be rejected by implementations.
 
-**Node-to-Action binding** (three-tier resolution):
+**Node-to-Tool binding** (three-tier resolution):
 
 | Tier | Condition | Resolution |
 |------|-----------|------------|
-| Bound | Node ID present in `bindings` | Fetch the Action definition grain by hash; use its `tool_name`, `input_schema`, `output_schema` |
-| Named | No binding, but an Action definition grain exists with matching `tool_name` | Resolve by convention (implementation-defined lookup) |
+| Bound | Node ID present in `bindings` | Fetch the Tool definition grain by hash; use its `tool_name`, `input_schema`, `output_schema` |
+| Named | No binding, but an Tool definition grain exists with matching `tool_name` | Resolve by convention (implementation-defined lookup) |
 | Abstract | No binding, no matching tool | Node label is a human-readable instruction; executor (LLM or agent) interprets it |
 
-**Execution record relation:** When an agent executes a workflow node, it creates an Tool grain (phase: complete or call/result) with a relation of type `mg:step_action:<node_id>` targeting the Workflow grain hash. This links execution records to the plan without modifying the immutable Workflow grain.
+**Execution record relation:** When an agent executes a workflow node, it creates a Tool grain (phase: complete or call/result) with a relation of type `mg:step_action:<node_id>` targeting the Workflow grain hash. This links execution records to the plan without modifying the immutable Workflow grain.
 
 **Example — linear pipeline:**
 
@@ -909,12 +909,12 @@ Directed graph of procedural steps — plans, pipelines, and multi-path processe
 }
 ```
 
-### 8.5 Action (type = 0x05)
+### 8.5 Tool (type = 0x05)
 
-A record of a tool invocation, code execution, or computer-use action. See §27.1 for the full `action_phase` discriminator and field tables.
+A record of a tool invocation, code execution, or computer-use action. See §27.1 for the full `tool_phase` discriminator and field tables.
 
 **Required fields:**
-- `type` = "action"
+- `type` = "tool"
 - Phase-dependent required fields (see §27.1)
 - `created_at` (int64, epoch ms)
 
@@ -2447,11 +2447,11 @@ The `observation_scope` field is a **closed enum**. It describes the temporal br
 
 This section provides detailed field specifications for each standard grain type. For Tool grain phase fields, see §27.1. For Observer types, see §24. For Observation modes/scopes, see §25/§26.
 
-### 27.1 Action Grain (type = 0x05) — Phase and Mode Details
+### 27.1 Tool Grain (type = 0x05) — Phase and Mode Details
 
-The `action_phase` field acts as a discriminator for async vs. synchronous tool call recording.
+The `tool_phase` field acts as a discriminator for async vs. synchronous tool call recording.
 
-**`action_phase` discriminator:**
+**`tool_phase` discriminator:**
 
 | Value | Meaning | Required fields | Absent fields |
 |---|---|---|---|
@@ -2496,8 +2496,8 @@ The `action_phase` field acts as a discriminator for async vs. synchronous tool 
 
 ```json
 {
-  "type": "action",
-  "action_phase": "definition",
+  "type": "tool",
+  "tool_phase": "definition",
   "tool_name": "get_weather",
   "tool_description": "Get the current weather in a given location.",
   "input_schema": {
@@ -2528,7 +2528,7 @@ The `action_phase` field acts as a discriminator for async vs. synchronous tool 
 
 ```json
 {
-  "type": "action",
+  "type": "tool",
   "tool_name": "get_weather",
   "tool_call_id": "toulu_01A09q90qw90lq917835lq9",
   "input": {"location": "San Francisco, CA", "unit": "celsius"},
@@ -2543,7 +2543,7 @@ The `action_phase` field acts as a discriminator for async vs. synchronous tool 
 
 ```json
 {
-  "type": "action",
+  "type": "tool",
   "execution_mode": "code_exec",
   "code": "import pandas as pd\ndf = pd.read_csv('data.csv')\nprint(df.describe())",
   "interpreter_id": "session-abc123",
@@ -2556,7 +2556,7 @@ The `action_phase` field acts as a discriminator for async vs. synchronous tool 
 
 **Alignment with Anthropic API:**
 
-| Anthropic API field | OMS Action field |
+| Anthropic API field | OMS Tool field |
 |---|---|
 | `tool.name` | `tool_name` (definition grain) |
 | `tool.description` | `tool_description` |
@@ -2733,12 +2733,12 @@ Implementations MAY index Observation grains whose `observer_type` starts with `
 }
 ```
 
-### 27.7 Consensus Grain Usage for Action Definition Validation
+### 27.7 Consensus Grain Usage for Tool Definition Validation
 
-When multiple independent sources produce or validate the same Action definition grain, a Consensus grain (type 0x09) records the agreement. This pattern is useful for integration platforms where definitions may be synthesized by LLMs, parsed from OpenAPI specs, validated against reference data, or refined by execution feedback analysis.
+When multiple independent sources produce or validate the same Tool definition grain, a Consensus grain (type 0x09) records the agreement. This pattern is useful for integration platforms where definitions may be synthesized by LLMs, parsed from OpenAPI specs, validated against reference data, or refined by execution feedback analysis.
 
 **Semantics:**
-- `agreed_content` is the content address of the Action definition grain that achieved consensus.
+- `agreed_content` is the content address of the Tool definition grain that achieved consensus.
 - Each entry in `participating_observers` is a DID identifying a validation source.
 - `dissent_grains` link to alternative definitions that did not achieve consensus.
 - Consensus achievement (`agreement_count >= threshold`) serves as a confidence signal for tool catalog quality.
@@ -2759,7 +2759,7 @@ When multiple independent sources produce or validate the same Action definition
   "dissent_count": 1,
   "agreed_content": "<content-address-of-validated-definition-grain>",
   "dissent_grains": ["<content-address-of-alternative-definition>"],
-  "structural_tags": ["consensus:action-definition"],
+  "structural_tags": ["consensus:tool-definition"],
   "namespace": "axtion:connectors:github",
   "related_to": [
     {"hash": "<definition-grain-hash>", "relation_type": "supports", "weight": 1.0}
@@ -2880,7 +2880,7 @@ The `object` map is an open schema. Standard keys:
 |---|---|---|
 | `name` | string | Human-readable agent name |
 | `description` | string | Agent purpose and capabilities summary |
-| `supported_tools` | array[string] | Tool names this agent can invoke (cross-reference with Action definition grains) |
+| `supported_tools` | array[string] | Tool names this agent can invoke (cross-reference with Tool definition grains) |
 | `input_modalities` | array[string] | `"text"`, `"image"`, `"audio"`, `"video"`. What the agent can consume. |
 | `output_modalities` | array[string] | What the agent can produce |
 | `protocol` | string | Communication protocol: `"oms"`, `"mcp"`, `"a2a"`, `"custom"`. Open enum. |
@@ -3209,12 +3209,12 @@ Applies to grains that represent REST API connectors, tool catalog entries, webh
 - `int:response_mapping` MUST be a valid JQ expression if present.
 - `int:rate_limit` is advisory only — enforcement is an implementation concern.
 
-**Example — Action definition with integration profile:**
+**Example — Tool definition with integration profile:**
 
 ```json
 {
-  "type": "action",
-  "action_phase": "definition",
+  "type": "tool",
+  "tool_phase": "definition",
   "tool_name": "github:create-issue",
   "tool_description": "Create a new issue in a GitHub repository",
   "input_schema": {
@@ -3264,7 +3264,7 @@ header-fields = flags-byte type-byte ns-hash-bytes created-at-bytes
                 ; version-byte + header-fields = 9-byte "fixed header" in §3.1
 flags-byte    = %x00-FF
 type-byte     = %x01-0A / %xF0-FF
-                ; Fact=0x01, Event=0x02, State=0x03, Workflow=0x04, Action=0x05,
+                ; Fact=0x01, Event=0x02, State=0x03, Workflow=0x04, Tool=0x05,
                 ; Observation=0x06, Goal=0x07, Reasoning=0x08, Consensus=0x09,
                 ; Consent=0x0A, 0x0B-0xEF reserved, 0xF0-0xFF domain profile types
 ns-hash-bytes = 2OCTET  ; uint16 big-endian, first two bytes of SHA-256(namespace)
@@ -3382,11 +3382,11 @@ footer        = 32OCTET  ; SHA-256 checksum
 }
 ```
 
-**Action-Specific Fields:**
+**Tool-Specific Fields:**
 
 ```json
 {
-  "aphase": "action_phase",
+  "aphase": "tool_phase",
   "tn": "tool_name",
   "inp": "input",
   "cnt": "content",
@@ -3656,7 +3656,7 @@ content_address = sha256(blob).hex()
 
 ---
 
-**Document Status:** This is a v1.3 revision of the .mg format specification. This revision adds `output_schema` to the Tool grain definition phase, introduces the Integration domain profile (`profile:integration`) for REST API connectors and tool catalogs, documents trigger definition conventions via Observation grains, and documents Consensus grain usage patterns for multi-source action definition validation. Submitted as a standards track document for consideration as an IETF RFC and W3C standard. Community feedback is encouraged through issue tracking and discussion forums.
+**Document Status:** This is a v1.4 revision of the .mg format specification. This revision renames grain type `0x01` from `belief` to `fact` and grain type `0x05` from `action` to `tool` (byte values unchanged — existing content addresses remain valid), redesigns the Workflow grain as a directed graph, and adds the `embedding_text` common field for retrieval. Submitted as a standards track document for consideration as an IETF RFC and W3C standard. Community feedback is encouraged through issue tracking and discussion forums.
 
-**Last Updated:** 2026-03-03
+**Last Updated:** 2026-06-12
 **License:** This document is offered under the Open Web Foundation Final Specification Agreement (OWFa 1.0)


### PR DESCRIPTION
Renames grain type **0x01 `belief` → `fact`** and **0x05 `action` → `tool`** across the full spec family — `SPECIFICATION.md`, the CAL and SML companion specs, and `README.md`.

**Byte values unchanged** (0x01/0x05) — existing `.mg` content addresses stay valid. **No backward compatibility**: legacy `belief`/`action` type strings are rejected.

Scope:
- Grain-type tables, type strings, SML tags (`<belief>`→`<fact>`, `<action>`→`<tool>`), `action_phase`→`tool_phase`, CAL grammar/field tables, and the unknown-grain suggestion example.
- Generic `action` left intact (consent `action=`, protocol action verbs, permission scope, `mg:step_action` relation).
- **Version 1.3 → 1.4** per maintainer guidance (next decimal); `[Unreleased]` changelog block becomes `[1.4]`; history preserved.