### PR TITLE
spec: OMS v1.4 — belief→fact/action→tool rename + Skill grain (0x0B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 
 ---
 
-## [1.4] — 2026-06-12
+## [1.4] — 2026-06-13
 
 ### Added
 
+- **Skill grain type (`0x0B`, §8.11)** — new dedicated cognitive grain type for packaged, reusable agent capabilities. Promotes the former §28.8 Skill Convention (a `Fact + mg:capable_of` pattern) to a first-class type, following the precedent set by Consent (§8.10). A Skill grain is **hybrid**: durable *definition* fields specify what the capability is and how to perform it, while optional *learned-competence* fields record a given agent's mastery. Required fields: `name`, `description`, `created_at`. Optional definition fields: `instructions`, `when_to_use`, `version`, `allowed_tools`, `resources`, `dependencies`, `input_modalities`, `output_modalities`, `domain`. Optional learned-competence fields: `holder_did`, `proficiency`, `practice_count`, `last_practiced_at`, `strategies` (each referencing a Workflow grain), `transferable`. A grain may be a pure definition (no `holder_did`/`proficiency`) or a held instance. Byte values `0x01`–`0x0A` are unchanged; existing content addresses remain valid.
+- **§6.12 Skill-Specific Fields** — compaction table for the Skill grain's type-specific fields, grouped definition/learned (`skname`, `instr`, `wtu`, `sver`, `atls`, `res`, `deps`, `imod`, `omod`, `dom`, `hdid`, `prof`, `prcnt`, `lpa`, `strat`, `xfer`). (Former §6.12 Compaction Rules renumbered to §6.13.)
+- **Skill compaction (Appendix C)** — added a Skill-Specific Fields compaction block.
 - **`embedding_text` common field (§6.1)** — optional `string` (compact key: `et`) providing source text for vector embedding and full-text indexing. When present, implementations SHOULD use this value instead of the grain's default per-type text representation. Enables document-derived grains to preserve source paragraph context for retrieval while maintaining structured subject/relation/object triples. Benchmarked at +29.4pp Recall@10 improvement on a 28-grain refund policy dataset. See `proposals/embedding-text-field.md`.
 - **Appendix C** — added `"et": "embedding_text"` to core field compaction table.
 - **Workflow grain type redesigned as directed graph (§8.4)** — Workflow grains now model directed graphs instead of flat step lists. New fields: `nodes` (array[string]), `edges` (array[map] with `src`, `dst`, `cond`, `max_cycles`), `bindings` (map[string→string] mapping node IDs to Tool definition grain hashes), `retries` (map[string→int]). Supports sequential, parallel fork/join, conditional branching, and bounded cycles. Three-tier node-to-Tool resolution (bound → named → abstract). Replaces `steps` array.
@@ -21,13 +24,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 
 ### Changed
 
-- **Type renames (breaking):** `"belief"` → `"fact"` (0x01), `"action"` → `"tool"` (0x05). Byte values unchanged; existing content addresses remain valid. The `Fact` grain is the (subject, relation, object) semantic triple with confidence; the `Tool` grain records tool/action invocations and executions. Updates the grain-type table (§5), the type-specific field headings, the relation vocabulary, and the §28.8 Skill Convention `mg:capable_of` mapping (now a `Fact` grain). Legacy `"belief"`/`"action"` type strings are not accepted.
+- **Type renames (breaking):** `"belief"` → `"fact"` (0x01), `"action"` → `"tool"` (0x05). Byte values unchanged; existing content addresses remain valid. The `Fact` grain is the (subject, relation, object) semantic triple with confidence; the `Tool` grain records tool/action invocations and executions. Updates the grain-type table (§5), the type-specific field headings, and the relation vocabulary. Legacy `"belief"`/`"action"` type strings are not accepted.
+- **§28.8 retitled** "Skill Convention" → "Skill Lifecycle and Transfer" — now defines lifecycle, transfer, and discovery over the dedicated Skill grain (§8.11) rather than the legacy `Fact + mg:capable_of` object-map pattern; discovery/transfer queries use `type=skill`. `mg:capable_of` now maps to the Skill grain in the §8 relation vocabulary (retained for backward compatibility).
+- **Grain-type table (§3.1), glossary, ABNF/CDDL `type-byte`, and conformance Level 1** updated to include Skill (`0x0B`); reserved range narrowed to `0x0C–0xEF`.
 - **Workflow grain description** — "Learned action sequence — procedural memory" → "Directed graph of procedural steps — plans, pipelines, processes".
 - **Workflow fields** — `steps` (array[string]) and `trigger` (string) replaced by `nodes`, `edges`, `bindings`, `retries`, and optional `trigger`. Edge schema uses nested `src`/`dst`/`cond`/`max_cycles` fields with compaction keys.
 - **`mg:requires_steps`** renamed to **`mg:has_graph`** in the `mg:` standard relation vocabulary.
 
 ### CAL 1.1 — Added
 
+- **Skill grain support** — `skill`/`skills` added to the closed grain-type set (§5.1); `RECALL skills` with type-specific fields (`name`, `version`, `domain`, `holder_did`, `proficiency`, `transferable`, `practice_count`, `last_practiced_at`); `ADD skill` (required SET fields `name`, `description`); `<skill>` content-projection rule; TOON column set; field-count row. Grammar productions `grain_type_plural`, `grain_type_singular`, `grain_field_name`, and new `skill_field` updated. `mg:capable_of` added to the `AGENCY` relation-category shortcut.
 - **Multi-format output (§10.1.1)** — `FORMAT` and `AS` clauses now accept bracketed format lists (`FORMAT [markdown, json]`) with optional aliases (`FORMAT [json AS structured, markdown AS report]`). Single query execution produces multiple renderings. New multi-format response shape (`"formats"` object, §14.2.1). Maximum 5 formats per list. New error codes: `CAL-E110` (too many formats), `CAL-E113` (duplicate format key).
 - **Workflow graph syntax for ADD/SUPERSEDE (§8.8.1)** — dedicated graph syntax for workflow grains using `->` (sequential edges), `()` (parallel fork/join), `WHEN` (conditional edges), `* N` (retry bounds), `BIND` (node-to-Action mapping), and `ON` (trigger clause). Full graph replacement on SUPERSEDE.
 - **`BECAUSE` alias** — accepted as synonym for `REASON` in ADD, SUPERSEDE, and workflow statements.
@@ -37,7 +43,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 - **Pipeline operators removed** — bare pipe syntax (`| ORDER BY`, `| LIMIT`, `| COUNT`, etc.) replaced by direct clause syntax (`ORDER BY`, `LIMIT`, `COUNT`). All examples and grammar productions updated. Backward-compatible at the semantic level.
 - **Workflow query fields** — `steps` field replaced by `node` and `binding` for grain-type-specific querying.
 - **Workflow content projection** — `nodes` joined with `->` arrow syntax replaces numbered `steps` list in SML/template output.
-- **`GrainTypeNotAddable` (CAL-E051)** — Workflow added to the set of addable grain types (Fact, Observation, Goal, Workflow).
+- **`GrainTypeNotAddable` (CAL-E051)** — addable grain-type set is now Fact, Observation, Goal, Workflow, Skill; the error message was updated to match.
+
+### CAL 1.1 — Fixed
+
+- **Stale `belief`/`action` literals** — corrected leftovers the rename missed: `grain_type_plural` (`beliefs`/`actions` → `facts`/`tools`), `RECALL MY beliefs` → `RECALL MY facts`, the TOON column table and examples, and a `"grain_type": "beliefs"` JSON example.
+
+### SML — Added
+
+- **`<skill>` element** — new tag mapping to the Skill grain; added to the all-grain-types comprehensive example. Default content is the skill `description`; default attributes `name`, `proficiency`?, `domain`?.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 
 ---
 
-## [Unreleased]
+## [1.4] — 2026-06-12
 
 ### Added
 
 - **`embedding_text` common field (§6.1)** — optional `string` (compact key: `et`) providing source text for vector embedding and full-text indexing. When present, implementations SHOULD use this value instead of the grain's default per-type text representation. Enables document-derived grains to preserve source paragraph context for retrieval while maintaining structured subject/relation/object triples. Benchmarked at +29.4pp Recall@10 improvement on a 28-grain refund policy dataset. See `proposals/embedding-text-field.md`.
 - **Appendix C** — added `"et": "embedding_text"` to core field compaction table.
-- **Workflow grain type redesigned as directed graph (§8.4)** — Workflow grains now model directed graphs instead of flat step lists. New fields: `nodes` (array[string]), `edges` (array[map] with `src`, `dst`, `cond`, `max_cycles`), `bindings` (map[string→string] mapping node IDs to Action definition grain hashes), `retries` (map[string→int]). Supports sequential, parallel fork/join, conditional branching, and bounded cycles. Three-tier node-to-Action resolution (bound → named → abstract). Replaces `steps` array.
+- **Workflow grain type redesigned as directed graph (§8.4)** — Workflow grains now model directed graphs instead of flat step lists. New fields: `nodes` (array[string]), `edges` (array[map] with `src`, `dst`, `cond`, `max_cycles`), `bindings` (map[string→string] mapping node IDs to Tool definition grain hashes), `retries` (map[string→int]). Supports sequential, parallel fork/join, conditional branching, and bounded cycles. Three-tier node-to-Tool resolution (bound → named → abstract). Replaces `steps` array.
 - **Workflow structural semantics (§8.4)** — node types inferred from graph topology: fork (multiple outgoing edges), AND-join (multiple incoming edges), decision point (conditional edges), terminal (no outgoing edges). Entry point is first element of `nodes`.
 - **`mg:has_graph` relation** — replaces `mg:requires_steps` for Workflow grains. Reflects the directed graph model.
 
@@ -37,7 +37,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 - **Pipeline operators removed** — bare pipe syntax (`| ORDER BY`, `| LIMIT`, `| COUNT`, etc.) replaced by direct clause syntax (`ORDER BY`, `LIMIT`, `COUNT`). All examples and grammar productions updated. Backward-compatible at the semantic level.
 - **Workflow query fields** — `steps` field replaced by `node` and `binding` for grain-type-specific querying.
 - **Workflow content projection** — `nodes` joined with `->` arrow syntax replaces numbered `steps` list in SML/template output.
-- **`GrainTypeNotAddable` (CAL-E051)** — Workflow added to the set of addable grain types (Belief, Observation, Goal, Workflow).
+- **`GrainTypeNotAddable` (CAL-E051)** — Workflow added to the set of addable grain types (Fact, Observation, Goal, Workflow).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 
 ### Changed
 
+- **Type renames (breaking):** `"belief"` → `"fact"` (0x01), `"action"` → `"tool"` (0x05). Byte values unchanged; existing content addresses remain valid. The `Fact` grain is the (subject, relation, object) semantic triple with confidence; the `Tool` grain records tool/action invocations and executions. Updates the grain-type table (§5), the type-specific field headings, the relation vocabulary, and the §28.8 Skill Convention `mg:capable_of` mapping (now a `Fact` grain). Legacy `"belief"`/`"action"` type strings are not accepted.
 - **Workflow grain description** — "Learned action sequence — procedural memory" → "Directed graph of procedural steps — plans, pipelines, processes".
 - **Workflow fields** — `steps` (array[string]) and `trigger` (string) replaced by `nodes`, `edges`, `bindings`, `retries`, and optional `trigger`. Edge schema uses nested `src`/`dst`/`cond`/`max_cycles` fields with compaction keys.
 - **`mg:requires_steps`** renamed to **`mg:has_graph`** in the `mg:` standard relation vocabulary.

--- a/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
+++ b/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
@@ -118,7 +118,7 @@ The line between Tier 0/1 (in CAL) and Tier 2 (not in CAL) is: **can the operati
 
 ### 1.5 Relationship to OMS
 
-CAL operates on the 10 grain types defined by OMS v1.4: Fact, Event, State, Workflow, Tool, Observation, Goal, Reasoning, Consensus, Consent. CAL treats this as a **closed set** -- custom types are not queryable via CAL.
+CAL operates on the 11 grain types defined by OMS v1.4: Fact, Event, State, Workflow, Tool, Observation, Goal, Reasoning, Consensus, Consent, Skill. CAL treats this as a **closed set** -- custom types are not queryable via CAL.
 
 CAL extends the Store Protocol Convention defined in OMS §28.4 ([SPECIFICATION.md](./SPECIFICATION.md)) with a formal query language. Where OMS defines the `query`, `search`, and `supersede` store operations, CAL provides a structured, deterministic syntax for invoking them safely.
 
@@ -405,7 +405,8 @@ meta_field_name = "recall_priority" | "epistemic_status" | "verification_status"
 
 grain_field_name = event_field | state_field | workflow_field
                  | action_field | observation_field | goal_field
-                 | reasoning_field | consensus_field | consent_field ;
+                 | reasoning_field | consensus_field | consent_field
+                 | skill_field ;
 
 event_field     = "role" | "session_id" | "parent_message_id" | "model_id" | "content" ;
 state_field     = "context" | "plan" ;
@@ -417,6 +418,8 @@ reasoning_field = "reasoning_type" | "premises" | "conclusion" ;
 consensus_field = "threshold" | "agreement_count" | "participating_observers" ;
 consent_field   = "consent_action" | "purpose" | "grantor_did" | "grantee_did"
                 | "scope" | "expires_at" ;
+skill_field     = "name" | "version" | "domain" | "holder_did" | "proficiency"
+                | "transferable" | "practice_count" | "last_practiced_at" ;
 
 comparator      = "=" | "!=" | ">=" | "<=" | ">" | "<" ;
 
@@ -527,11 +530,13 @@ hash_literal    = "sha256:" , hex_char{8,64} ;
 identifier      = letter , { letter | digit | "_" } ;
 positive_integer = digit+ ;
 
-grain_type_plural   = "beliefs" | "events" | "states" | "workflows" | "actions"
-                    | "observations" | "goals" | "reasonings" | "consensuses" | "consents" ;
+grain_type_plural   = "facts" | "events" | "states" | "workflows" | "tools"
+                    | "observations" | "goals" | "reasonings" | "consensuses"
+                    | "consents" | "skills" ;
 
 grain_type_singular = "fact" | "event" | "state" | "workflow" | "tool"
-                    | "observation" | "goal" | "reasoning" | "consensus" | "consent" ;
+                    | "observation" | "goal" | "reasoning" | "consensus"
+                    | "consent" | "skill" ;
 ```
 
 ---
@@ -552,6 +557,7 @@ grain_type_singular = "fact" | "event" | "state" | "workflow" | "tool"
 | Reasoning | `reasonings` | `reasoning` | 0x08 |
 | Consensus | `consensuses` | `consensus` | 0x09 |
 | Consent | `consents` | `consent` | 0x0A |
+| Skill | `skills` | `skill` | 0x0B |
 
 ### 5.2 Common Field Types
 
@@ -704,9 +710,22 @@ All Fact fields are in the common set (`subject`, `relation`, `object`, `confide
 | `scope` | String | `=` | Consent scope identifier |
 | `expires_at` | Temporal | `=`, `BETWEEN` | Consent expiration |
 
+#### Skill (0x0B) -- `RECALL skills`
+
+| Field | Type | Operators | Notes |
+|-------|------|-----------|-------|
+| `name` | String | `=`, `!=`, `IN` | Machine-readable skill identifier (e.g., `"code_review"`) |
+| `version` | String | `=`, `IN` | Skill-defined version string (e.g., `"2.1.0"`) |
+| `domain` | String | `=`, `IN` | Domain context (e.g., `"software"`) |
+| `holder_did` | String | `=` | DID of the agent that holds the skill (learned instances) |
+| `proficiency` | Number | `=`, `>=`, `<=`, `>`, `<` | Mastery level [0.0, 1.0] (learned instances) |
+| `transferable` | Boolean | `=` | Whether the skill can be transferred to another agent |
+| `practice_count` | Number | `=`, `>=`, `<=`, `>`, `<` | Successful applications |
+| `last_practiced_at` | Temporal | `=`, `BETWEEN` | Most recent successful application |
+
 ### 6.4 Type-Specific ADD Extensions
 
-When adding Goal or Observation grains, type-specific fields are available in SET clauses:
+When adding Goal, Observation, or Skill grains, type-specific fields are available in SET clauses:
 
 ```sql
 ADD goal
@@ -727,6 +746,15 @@ ADD observation
   SET observer_type = "agent:activity-tracker"
   SET confidence = 0.7
   REASON "observed pattern across last 4 weeks"
+
+ADD skill
+  SET name = "code_review"
+  SET description = "Review code changes for correctness, style, and security issues"
+  SET instructions = "Read the diff, classify the change, then apply the matching strategy; check auth and input-handling paths first."
+  SET when_to_use = "a pull request or code diff needs review before merge"
+  SET version = "2.1.0"
+  SET domain = "software"
+  REASON "authoring reusable code-review skill definition"
 ```
 
 ### 6.5 Field Count Summary
@@ -743,6 +771,7 @@ ADD observation
 | Reasoning | 18 | 3 | 21 |
 | Consensus | 18 | 3 | 21 |
 | Consent | 18 | 6 | 24 |
+| Skill | 18 | 8 | 26 |
 | _(no type)_ | 18 | 0 | 18 |
 
 ---
@@ -773,6 +802,7 @@ OMS defines a standard `mg:` relation vocabulary. CAL provides first-class suppo
 | `mg:delegates_to` | Agency | Entity | Agent DID | Delegation |
 | `mg:owned_by` | Knowledge | Resource | Entity | Ownership |
 | `mg:has_capability` | Agency | Agent DID | Capability | Agent capability |
+| `mg:capable_of` | Agency | Agent DID | Skill | Learned skill (Skill grain, 0x0B) |
 | `mg:handed_off_to` | Interaction | Agent DID | Agent DID | Agent handoff |
 | `mg:depends_on` | Lifecycle | Goal | Goal | Goal dependency |
 | `mg:assigned_to` | Agency | Task | Agent DID | Task assignment |
@@ -787,7 +817,7 @@ CAL defines **relation category shortcuts** as syntactic sugar for common multi-
 | `relation IS KNOWLEDGE` | `relation IN ("mg:knows", "mg:infers")` |
 | `relation IS PERMISSION` | `relation IN ("mg:permits", "mg:revokes", "mg:prohibits")` |
 | `relation IS INTERACTION` | `relation IN ("mg:said", "mg:did", "mg:handed_off_to")` |
-| `relation IS AGENCY` | `relation IN ("mg:delegates_to", "mg:has_capability", "mg:assigned_to")` |
+| `relation IS AGENCY` | `relation IN ("mg:delegates_to", "mg:has_capability", "mg:capable_of", "mg:assigned_to")` |
 | `relation IS LIFECYCLE` | `relation IN ("mg:intends", "mg:depends_on")` |
 | `relation IS OBSERVATION` | `relation IN ("mg:perceives", "mg:state_at")` |
 
@@ -993,9 +1023,11 @@ ADD fact
   REASON "user stated preference during onboarding conversation"
 ```
 
-**Addable grain types:** Fact, Observation, Goal, Workflow. Events, Tools, States, and other types represent system-generated records and are not user-creatable.
+**Addable grain types:** Fact, Observation, Goal, Workflow, Skill. Events, Tools, States, and other types represent system-generated records and are not user-creatable.
 
 **Required SET fields (Fact):** `subject`, `relation`, `object`. `REASON` is mandatory.
+
+**Required SET fields (Skill):** `name`, `description`. `REASON` is mandatory.
 
 #### 8.8.1 ADD Workflow (Graph Syntax)
 
@@ -1192,7 +1224,7 @@ RECALL LIKE "machine learning best practices"
 ### 9.5 MY
 
 ```sql
-RECALL MY beliefs
+RECALL MY facts
 -- Desugars to: RECALL facts WHERE user_id = $current_user_id
 ```
 
@@ -1317,6 +1349,7 @@ Each grain type defines a **content rule** (what becomes the text content of the
 | **Workflow** | `nodes` (joined as readable text) | `trigger`? |
 | **Consensus** | `object` (the agreed claim) | `threshold`?, `count`? |
 | **Consent** | `purpose` | `action`, `grantor`, `grantee` |
+| **Skill** | `description` (what the skill enables) | `name`, `proficiency`?, `domain`? |
 
 Attributes marked with `?` are included at `standard` and `full` disclosure levels only, omitted at `summary` level.
 
@@ -1478,7 +1511,7 @@ FORMAT TEMPLATE {
 }
 ```
 
-**All 10 grain types rendered:**
+**All 11 grain types rendered:**
 ```sml
 <context intent="helping alice prepare her Q1 engineering review">
 
@@ -1509,6 +1542,8 @@ FORMAT TEMPLATE {
   <consensus threshold="3" count="4">Q1 deployment frequency improved 18% over Q4 2025</consensus>
 
   <consent action="granted" grantor="alice" grantee="agent">access engineering metrics dashboards for review preparation</consent>
+
+  <skill name="metrics_review" proficiency="0.82" domain="software">summarise quarterly engineering metrics and surface the reliability narrative</skill>
 
 </context>
 ```
@@ -1588,7 +1623,7 @@ value1,value2,...
 ```
 
 Where:
-- `type` is the grain type (plural form, lowercase): `beliefs`, `events`, `goals`, etc.
+- `type` is the grain type (plural form, lowercase): `facts`, `events`, `goals`, etc.
 - `[N]` is the count of rows.
 - `{col1,col2,...}` are the projected field names.
 - The trailing `:` on the header is **required** by the TOON grammar (`header = [key] bracket-seg [fields-seg] ":"`).
@@ -1598,23 +1633,24 @@ Where:
 
 | Grain Type | Columns (standard disclosure) |
 |-----------|-------------------------------|
-| `beliefs` | `subject`, `content`, `confidence` |
+| `facts` | `subject`, `content`, `confidence` |
 | `events` | `role`, `time`, `content` |
 | `goals` | `subject`, `content`, `state` |
-| `actions` | `tool`, `phase`, `content` |
+| `tools` | `tool`, `phase`, `content` |
 | `observations` | `observer`, `content` |
 | `reasonings` | `type`, `content` |
 | `states` | `context`, `content` |
 | `workflows` | `trigger`, `content` |
 | `consensuses` | `threshold`, `count`, `content` |
 | `consents` | `grantor`, `grantee`, `action`, `content` |
+| `skills` | `name`, `content`, `proficiency` |
 
 At `summary` disclosure, `confidence`, `state`, `phase`, and `type` columns are omitted.
 At `full` disclosure, additional columns `source` and `observed` are appended.
 
 **Example — `RECALL facts ABOUT "alice" LIMIT 3 AS toon`:**
 ```
-beliefs[3]{subject,content,confidence}:
+facts[3]{subject,content,confidence}:
 alice,prefers dark mode,0.95
 alice,prefers vim,0.9
 alice,works best in deep-focus blocks of 90 minutes,0.82
@@ -1663,7 +1699,7 @@ Rules:
 context: agent_context
 intent: helping alice prepare her Q1 engineering review
 tokens: 1847/2000
-beliefs[3]{subject,content,confidence}:
+facts[3]{subject,content,confidence}:
   alice,prefers dark mode,0.95
   alice,prefers vim,0.9
   alice,works best in deep-focus blocks of 90 minutes,0.82
@@ -2058,7 +2094,7 @@ CAL/1 RECALL facts ABOUT "alice" WHERE confidence >= 0.8 RECENT 5 AS markdown
 {
   "cal_version": 1,
   "statement": "recall",
-  "grain_type": "beliefs",
+  "grain_type": "facts",
   "about": "alice",
   "where": [{ "field": "confidence", "op": ">=", "value": 0.8 }],
   "recent": 5,
@@ -2600,8 +2636,8 @@ It can read, assemble, and evolve memories, but never delete them.
   SUPERSEDE sha256:hash SET field = value [SET ...] REASON "why"
   REVERT sha256:hash REASON "why"
 
-### Types: beliefs, events, states, workflows, actions, observations, goals,
-           reasonings, consensuses, consents
+### Types: facts, events, states, workflows, tools, observations, goals,
+           reasonings, consensuses, consents, skills
 
 ### WHERE conditions (combine with AND):
   query = "search text"           -- semantic search
@@ -2639,7 +2675,7 @@ It can read, assemble, and evolve memories, but never delete them.
 
 ### Output formats:
   sml (default structured): flat tag-based — <fact subject="alice" confidence="0.92">prefers dark mode</fact>
-  toon: CSV-tabular, ~40% fewer tokens — beliefs[3]{subject,content,confidence}:\nalice,prefers dark mode,0.95
+  toon: CSV-tabular, ~40% fewer tokens — facts[3]{subject,content,confidence}:\nalice,prefers dark mode,0.95
   markdown: human-readable prose
   json: machine-readable structured data
   text: minimal plain text
@@ -2733,7 +2769,7 @@ All error codes use the `CAL-E` prefix.
 | CAL-E045 | NamespaceMismatch -- target grain in different namespace |
 | CAL-E046 | TargetNotFound -- target hash does not exist |
 | CAL-E050 | MissingRequiredField -- ADD requires subject, relation, object |
-| CAL-E051 | GrainTypeNotAddable -- only Fact, Observation, Goal can be created |
+| CAL-E051 | GrainTypeNotAddable -- only Fact, Observation, Goal, Workflow, Skill can be created |
 | CAL-E052 | AddQuotaExceeded -- too many ADD operations |
 
 ### Multi-Format Errors (CAL-E110, CAL-E113)
@@ -2933,12 +2969,12 @@ CHUNK, PAUSE, RESUME, CANCEL
 
 | Version | Date | Change |
 |---------|------|--------|
-| 1.1 | 2026-03-05 | Multi-format output: FORMAT and AS clauses accept bracketed format lists (`FORMAT [markdown, json]`). Single query execution produces multiple renderings. New Section 10.1.1 (syntax and rules), Section 14.2.1 (multi-format response shape), error code CAL-E110. Backward-compatible — single-format syntax unchanged. |
+| 1.1 | 2026-03-05 | Multi-format output: FORMAT and AS clauses accept bracketed format lists (`FORMAT [markdown, json]`). Single query execution produces multiple renderings. New Section 10.1.1 (syntax and rules), Section 14.2.1 (multi-format response shape), error code CAL-E110. Backward-compatible — single-format syntax unchanged. As part of the OMS v1.4 release, also adds the Skill grain type (`0x0B`) to the closed query set (`RECALL skills` / `ADD skill`, type-specific field set, `<skill>` projection, TOON columns, `mg:capable_of` in the `AGENCY` shortcut) and corrects `belief`/`action` literals the rename left behind (`grain_type_plural`, `RECALL MY`, TOON tables, `DESCRIBE` listing, `CAL-E051`). |
 | 1.0 | 2026-03-03 | Initial CAL specification. 12-variant statement model. Tier 0 (RECALL, ASSEMBLE, SetOp, EXISTS, HISTORY, EXPLAIN, DESCRIBE, BATCH, COALESCE) + Tier 1 (ADD, SUPERSEDE, REVERT). ASSEMBLE with budget, priority, format, streaming. Semantic shortcuts (ABOUT, RECENT, SINCE, LIKE, MY, CONTRADICTIONS, BETWEEN). LET bindings. Custom FORMAT templates (Mustache-subset). Grain-type-specific queryable fields for all 10 OMS types. mg: relation vocabulary with category shortcuts. Domain profile querying. Dual wire format (text/cal + application/json+cal). Internationalization (Unicode NFC, cross-lingual search, bidi safety). Streaming protocol (SSE, NDJSON, WebSocket). THREAD shorthand. HISTORY AS OF and DIFF. Non-destructive safety model. Content Projection Model with flat semantic output (Section 10.3-10.4). PROJECT clause for custom field surfacing. Per-grain-type content projection rules with humanize() and time humanization. ELEMENT/ELEMENT_SUMMARY/SOURCE_BREAK template sections for flat semantic rendering. TOON (Token-Oriented Object Notation) format support — `toon` as a first-class FORMAT/AS preset (Section 10.9): tabular CSV rendering for uniform RECALL results, grouped-section rendering for ASSEMBLE results, per-grain-type column sets at each disclosure level, PROJECT integration, STREAM compatibility, auto-TOON budget-pressure hint (CAL-W005). |
 
 ---
 
-**Document Status:** This is the CAL (Context Assembly Language) Specification v1.0. It defines a non-destructive, deterministic, LLM-native context assembly and evolution language for OMS-compliant memory databases. CAL is part of the Open Memory Specification (OMS) v1.4 — see [SPECIFICATION.md](./SPECIFICATION.md).
+**Document Status:** This is the CAL (Context Assembly Language) Specification v1.1. It defines a non-destructive, deterministic, LLM-native context assembly and evolution language for OMS-compliant memory databases. CAL is part of the Open Memory Specification (OMS) v1.4 — see [SPECIFICATION.md](./SPECIFICATION.md).
 
 **Last Updated:** 2026-03-05
 **License:** This specification is offered under the Open Web Foundation Final Specification Agreement (OWFa 1.0)

--- a/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
+++ b/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
@@ -1,7 +1,7 @@
 # CAL (Context Assembly Language) Specification v1.0
 
 **Status:** Standards Track | **Date:** 2026-03-05 | **Version:** 1.1 | **Classification:** Experimental
-**Part of:** [Open Memory Specification (OMS) v1.3](./SPECIFICATION.md)
+**Part of:** [Open Memory Specification (OMS) v1.4](./SPECIFICATION.md)
 ---
 
 ## Table of Contents
@@ -118,7 +118,7 @@ The line between Tier 0/1 (in CAL) and Tier 2 (not in CAL) is: **can the operati
 
 ### 1.5 Relationship to OMS
 
-CAL operates on the 10 grain types defined by OMS v1.3: Belief, Event, State, Workflow, Action, Observation, Goal, Reasoning, Consensus, Consent. CAL treats this as a **closed set** -- custom types are not queryable via CAL.
+CAL operates on the 10 grain types defined by OMS v1.4: Fact, Event, State, Workflow, Tool, Observation, Goal, Reasoning, Consensus, Consent. CAL treats this as a **closed set** -- custom types are not queryable via CAL.
 
 CAL extends the Store Protocol Convention defined in OMS §28.4 ([SPECIFICATION.md](./SPECIFICATION.md)) with a formal query language. Where OMS defines the `query`, `search`, and `supersede` store operations, CAL provides a structured, deterministic syntax for invoking them safely.
 
@@ -236,7 +236,7 @@ recall_priority, epistemic_status
 role, session_id, parent_message_id, model_id, content,
 context, plan,
 trigger, nodes, edges, bindings, retries,
-tool_name, action_phase, is_error, tool_call_id,
+tool_name, tool_phase, is_error, tool_call_id,
 observer_id, observer_type,
 goal_state, assigned_agent, deadline, depends_on,
 reasoning_type, premises, conclusion,
@@ -410,7 +410,7 @@ grain_field_name = event_field | state_field | workflow_field
 event_field     = "role" | "session_id" | "parent_message_id" | "model_id" | "content" ;
 state_field     = "context" | "plan" ;
 workflow_field  = "trigger" | "node" | "binding" ;
-action_field    = "tool_name" | "action_phase" | "is_error" | "tool_call_id" ;
+action_field    = "tool_name" | "tool_phase" | "is_error" | "tool_call_id" ;
 observation_field = "observer_id" | "observer_type" ;
 goal_field      = "goal_state" | "assigned_agent" | "deadline" | "depends_on" ;
 reasoning_field = "reasoning_type" | "premises" | "conclusion" ;
@@ -530,7 +530,7 @@ positive_integer = digit+ ;
 grain_type_plural   = "beliefs" | "events" | "states" | "workflows" | "actions"
                     | "observations" | "goals" | "reasonings" | "consensuses" | "consents" ;
 
-grain_type_singular = "belief" | "event" | "state" | "workflow" | "action"
+grain_type_singular = "fact" | "event" | "state" | "workflow" | "tool"
                     | "observation" | "goal" | "reasoning" | "consensus" | "consent" ;
 ```
 
@@ -542,11 +542,11 @@ grain_type_singular = "belief" | "event" | "state" | "workflow" | "action"
 
 | Type | Plural (after RECALL) | Singular (in ADD/WHERE) | OMS Type Code |
 |------|----------------------|------------------------|---------------|
-| Belief | `beliefs` | `belief` | 0x01 |
+| Fact | `facts` | `fact` | 0x01 |
 | Event | `events` | `event` | 0x02 |
 | State | `states` | `state` | 0x03 |
 | Workflow | `workflows` | `workflow` | 0x04 |
-| Action | `actions` | `action` | 0x05 |
+| Tool | `tools` | `tool` | 0x05 |
 | Observation | `observations` | `observation` | 0x06 |
 | Goal | `goals` | `goal` | 0x07 |
 | Reasoning | `reasonings` | `reasoning` | 0x08 |
@@ -610,7 +610,7 @@ Missing field = no match (never errors). `WHERE confidence >= 0.8` on a grain wi
 
 ### 6.1 Design Principle
 
-When a `RECALL` statement specifies a grain type (e.g., `RECALL actions`), the parser unlocks a **type-specific field set** for use in `WHERE` clauses. This enables precise querying of OMS-native fields that only exist on specific grain types, without polluting the global field namespace.
+When a `RECALL` statement specifies a grain type (e.g., `RECALL tools`), the parser unlocks a **type-specific field set** for use in `WHERE` clauses. This enables precise querying of OMS-native fields that only exist on specific grain types, without polluting the global field namespace.
 
 The type-specific field set is a **compile-time guarantee**: the parser MUST reject field references that do not belong to the specified grain type. When no grain type is specified (`RECALL WHERE ...`), only the common field set is available.
 
@@ -623,9 +623,9 @@ The type-specific field set is a **compile-time guarantee**: the parser MUST rej
 
 ### 6.3 Grain-Type-Specific Queryable Fields
 
-#### Belief (0x01) -- `RECALL beliefs`
+#### Fact (0x01) -- `RECALL facts`
 
-All Belief fields are in the common set (`subject`, `relation`, `object`, `confidence`). No additional type-specific fields.
+All Fact fields are in the common set (`subject`, `relation`, `object`, `confidence`). No additional type-specific fields.
 
 #### Event (0x02) -- `RECALL events`
 
@@ -650,16 +650,16 @@ All Belief fields are in the common set (`subject`, `relation`, `object`, `confi
 |-------|------|-----------|-------|
 | `trigger` | String | `=`, `!=` | Trigger condition (e.g., `"on:merge_to_main"`) |
 | `node` | String | `=` | Match workflows containing a specific node |
-| `binding` | String | `=` | Match workflows binding to a specific Action grain hash |
+| `binding` | String | `=` | Match workflows binding to a specific Tool grain hash |
 
-#### Action (0x05) -- `RECALL actions`
+#### Tool (0x05) -- `RECALL tools`
 
 | Field | Type | Operators | Notes |
 |-------|------|-----------|-------|
 | `tool_name` | String | `=`, `!=`, `IN` | Tool identifier |
-| `action_phase` | String | `=` | `"definition"`, `"call"`, `"result"`, `"complete"` |
-| `is_error` | Boolean | `=` | Whether the action resulted in error |
-| `tool_call_id` | String | `=` | Correlation ID across action phases |
+| `tool_phase` | String | `=` | `"definition"`, `"call"`, `"result"`, `"complete"` |
+| `is_error` | Boolean | `=` | Whether the tool resulted in error |
+| `tool_call_id` | String | `=` | Correlation ID across tool phases |
 
 #### Observation (0x06) -- `RECALL observations`
 
@@ -733,11 +733,11 @@ ADD observation
 
 | Grain Type | Common Fields | Type-Specific Fields | Total Queryable |
 |-----------|--------------|---------------------|----------------|
-| Belief | 18 | 0 | 18 |
+| Fact | 18 | 0 | 18 |
 | Event | 18 | 5 | 23 |
 | State | 18 | 2 | 20 |
 | Workflow | 18 | 2 | 20 |
-| Action | 18 | 4 | 22 |
+| Tool | 18 | 4 | 22 |
 | Observation | 18 | 2 | 20 |
 | Goal | 18 | 4 | 22 |
 | Reasoning | 18 | 3 | 21 |
@@ -795,7 +795,7 @@ CAL defines **relation category shortcuts** as syntactic sugar for common multi-
 
 ```sql
 -- All preference-related beliefs about alice
-RECALL beliefs WHERE subject = "alice" AND relation IS PREFERENCE
+RECALL facts WHERE subject = "alice" AND relation IS PREFERENCE
   ORDER BY confidence DESC
 
 -- All permission records for a DID
@@ -832,7 +832,7 @@ CAL/1 has **12 statement types** organized into three tiers:
 Retrieves grains matching the given filters. Returns results using the OMS Standard Search Response Envelope.
 
 ```sql
-RECALL beliefs WHERE subject = "alice" AND relation = "prefers"
+RECALL facts WHERE subject = "alice" AND relation = "prefers"
   WITH contradiction_detection
   ORDER BY confidence DESC
   LIMIT 10
@@ -842,11 +842,11 @@ RECALL supports semantic shortcuts (ABOUT, RECENT, SINCE, LIKE, MY, CONTRADICTIO
 
 ```sql
 -- With grain-type-specific fields
-RECALL actions WHERE tool_name = "get_weather" AND is_error = false
+RECALL tools WHERE tool_name = "get_weather" AND is_error = false
   ORDER BY time DESC LIMIT 20
 
 -- With domain profile fields
-RECALL beliefs WHERE tags INCLUDE ["profile:healthcare"]
+RECALL facts WHERE tags INCLUDE ["profile:healthcare"]
   AND hc:patient_id = "P-12345" AND relation = "mg:knows"
 ```
 
@@ -871,10 +871,10 @@ The flagship new statement. Composes a context block from multiple RECALL source
 CAL/1 ASSEMBLE user_context
   FOR "conversation about alice's preferences and goals"
   FROM
-    beliefs:  (RECALL beliefs ABOUT "alice" WHERE relation = "prefers" LIMIT 20),
+    beliefs:  (RECALL facts ABOUT "alice" WHERE relation = "prefers" LIMIT 20),
     goals:    (RECALL goals ABOUT "alice" RECENT 10),
     events:   (RECALL events WHERE user_id = "alice" RECENT 5),
-    history:  (RECALL beliefs ABOUT "alice"
+    history:  (RECALL facts ABOUT "alice"
                 WHERE relation = "prefers" WITH superseded
                 ORDER BY time DESC LIMIT 3)
   BUDGET 2000 tokens
@@ -943,10 +943,10 @@ HISTORY sha256:aaa... DIFF sha256:bbb...
 Returns the execution plan without running the query. Works with all statement types including ASSEMBLE.
 
 ```sql
-EXPLAIN RECALL beliefs WHERE query = "alice preferences" LIMIT 10
+EXPLAIN RECALL facts WHERE query = "alice preferences" LIMIT 10
 EXPLAIN ASSEMBLE user_context
   FOR "conversation about alice"
-  FROM beliefs: (RECALL beliefs ABOUT "alice"),
+  FROM beliefs: (RECALL facts ABOUT "alice"),
        goals: (RECALL goals ABOUT "alice" RECENT 5)
   BUDGET 2000 tokens
 ```
@@ -958,7 +958,7 @@ Schema introspection for grain types, fields, capabilities, server metadata, tem
 ```sql
 CAL/1 DESCRIBE grain_types        -- list available grain types
 CAL/1 DESCRIBE fields             -- list all queryable fields
-CAL/1 DESCRIBE fields belief      -- list fields for a specific grain type
+CAL/1 DESCRIBE fields fact      -- list fields for a specific grain type
 CAL/1 DESCRIBE capabilities       -- server capabilities and conformance
 CAL/1 DESCRIBE server             -- server metadata
 CAL/1 DESCRIBE templates          -- list registered templates
@@ -971,9 +971,9 @@ Multiple independent queries in a single request. Each sub-query gets its own re
 
 ```sql
 CAL/1 BATCH {
-  preferences: RECALL beliefs ABOUT "alice" WHERE relation = "prefers",
+  preferences: RECALL facts ABOUT "alice" WHERE relation = "prefers",
   recent:      RECALL events ABOUT "alice" RECENT 5,
-  team:        RECALL beliefs WHERE relation = "member_of" AND object = "team-alpha"
+  team:        RECALL facts WHERE relation = "member_of" AND object = "team-alpha"
 }
 ```
 
@@ -984,7 +984,7 @@ CAL/1 BATCH {
 Creates a **new** grain. Pure append-only -- does not modify or reference any existing grain.
 
 ```sql
-ADD belief
+ADD fact
   SET subject = "alice"
   SET relation = "prefers"
   SET object = "dark mode"
@@ -993,9 +993,9 @@ ADD belief
   REASON "user stated preference during onboarding conversation"
 ```
 
-**Addable grain types:** Belief, Observation, Goal, Workflow. Events, Actions, States, and other types represent system-generated records and are not user-creatable.
+**Addable grain types:** Fact, Observation, Goal, Workflow. Events, Tools, States, and other types represent system-generated records and are not user-creatable.
 
-**Required SET fields (Belief):** `subject`, `relation`, `object`. `REASON` is mandatory.
+**Required SET fields (Fact):** `subject`, `relation`, `object`. `REASON` is mandatory.
 
 #### 8.8.1 ADD Workflow (Graph Syntax)
 
@@ -1058,7 +1058,7 @@ ADD workflow "release pipeline"
 
 **Structural inference:** Node types are inferred from graph topology — a node with multiple unconditional outgoing edges is a fork, a node receiving multiple edges is an AND-join, a node with `WHEN` edges is a decision point.
 
-**BIND clause:** Maps a node name to an Action definition grain hash (`action_phase: "definition"`). The executor fetches the definition to discover `tool_name`, `input_schema`, etc. Unbound nodes are resolved by name convention or treated as abstract steps.
+**BIND clause:** Maps a node name to an Tool definition grain hash (`tool_phase: "definition"`). The executor fetches the definition to discover `tool_name`, `input_schema`, etc. Unbound nodes are resolved by name convention or treated as abstract steps.
 
 **Node names:** Bare identifiers (`build`, `unit_test`) or quoted strings (`"send welcome email"`). Reserved words (`ADD`, `workflow`, `ON`, `WHEN`, `BIND`, `REASON`, `BECAUSE`) must be quoted.
 
@@ -1073,7 +1073,7 @@ SUPERSEDE sha256:target_hash
   REASON "user explicitly changed preference"
 ```
 
-**Belief supersession:** At least one `SET` clause and `REASON` are required.
+**Fact supersession:** At least one `SET` clause and `REASON` are required.
 
 **Workflow supersession:** Uses graph syntax (full graph replacement):
 
@@ -1117,10 +1117,10 @@ LET bindings name intermediate RECALL results that can be referenced by `$name` 
 
 ```sql
 CAL/1
-LET $team_members = RECALL beliefs
+LET $team_members = RECALL facts
   WHERE relation = "member_of" AND object = "team-alpha" SUBJECTS;
 
-LET $team_prefs = RECALL beliefs
+LET $team_prefs = RECALL facts
   WHERE subject IN ($team_members) AND relation = "prefers";
 
 ASSEMBLE team_context
@@ -1145,10 +1145,10 @@ Evaluates argument queries left-to-right. Returns the result of the **first quer
 
 ```sql
 COALESCE(
-  RECALL beliefs WHERE subject = "alice" AND relation = "favorite_color",
-  RECALL beliefs WHERE subject = "alice" AND relation = "prefers"
+  RECALL facts WHERE subject = "alice" AND relation = "favorite_color",
+  RECALL facts WHERE subject = "alice" AND relation = "prefers"
     AND tags INCLUDE ["color"],
-  RECALL beliefs ABOUT "alice" LIKE "color preference"
+  RECALL facts ABOUT "alice" LIKE "color preference"
 )
 ```
 
@@ -1163,9 +1163,9 @@ Shortcuts are **syntactic sugar** -- they desugar to standard WHERE/pipeline cla
 ### 9.1 ABOUT
 
 ```sql
-RECALL beliefs ABOUT "alice"
--- Desugars to: RECALL beliefs WHERE subject = "alice"
--- Falls back to: RECALL beliefs WHERE query = "alice" (if no structural match)
+RECALL facts ABOUT "alice"
+-- Desugars to: RECALL facts WHERE subject = "alice"
+-- Falls back to: RECALL facts WHERE query = "alice" (if no structural match)
 ```
 
 ### 9.2 RECENT
@@ -1193,14 +1193,14 @@ RECALL LIKE "machine learning best practices"
 
 ```sql
 RECALL MY beliefs
--- Desugars to: RECALL beliefs WHERE user_id = $current_user_id
+-- Desugars to: RECALL facts WHERE user_id = $current_user_id
 ```
 
 ### 9.6 CONTRADICTIONS
 
 ```sql
-RECALL beliefs ABOUT "alice" CONTRADICTIONS
--- Desugars to: RECALL beliefs WHERE subject = "alice" AND contradicted = true
+RECALL facts ABOUT "alice" CONTRADICTIONS
+-- Desugars to: RECALL facts WHERE subject = "alice" AND contradicted = true
 --              WITH contradiction_detection
 ```
 
@@ -1248,15 +1248,15 @@ The `FORMAT` and `AS` clauses accept either a single format name or a bracketed 
 **Single format** (existing behavior):
 
 ```
-CAL/1 RECALL beliefs ABOUT "alice" FORMAT markdown
-CAL/1 RECALL beliefs ABOUT "alice" AS json
+CAL/1 RECALL facts ABOUT "alice" FORMAT markdown
+CAL/1 RECALL facts ABOUT "alice" AS json
 ```
 
 **Multi-format:**
 
 ```
-CAL/1 RECALL beliefs ABOUT "alice" FORMAT [markdown, json]
-CAL/1 RECALL beliefs ABOUT "alice" AS [markdown, json]
+CAL/1 RECALL facts ABOUT "alice" FORMAT [markdown, json]
+CAL/1 RECALL facts ABOUT "alice" AS [markdown, json]
 ```
 
 **Multi-format with aliases:**
@@ -1264,9 +1264,9 @@ CAL/1 RECALL beliefs ABOUT "alice" AS [markdown, json]
 Each format in a bracketed list MAY include an `AS <identifier>` alias. When present, the alias becomes the key in the multi-format response object (Section 14.2.1) instead of the canonical format name. Aliases are particularly useful when the list contains multiple templates (which would otherwise all share the key `"template"`) or when the client wants semantically meaningful keys.
 
 ```
-CAL/1 RECALL beliefs FORMAT [json AS customers, markdown AS report]
-CAL/1 RECALL beliefs FORMAT [json AS structured, TEMPLATE "{{subject}}: {{object}}" AS oneliner]
-CAL/1 RECALL beliefs FORMAT [TEMPLATE "{{subject}}" AS names, TEMPLATE "{{object}}" AS values]
+CAL/1 RECALL facts FORMAT [json AS customers, markdown AS report]
+CAL/1 RECALL facts FORMAT [json AS structured, TEMPLATE "{{subject}}: {{object}}" AS oneliner]
+CAL/1 RECALL facts FORMAT [TEMPLATE "{{subject}}" AS names, TEMPLATE "{{object}}" AS values]
 ```
 
 **Rules:**
@@ -1307,10 +1307,10 @@ Each grain type defines a **content rule** (what becomes the text content of the
 
 | Grain Type | Text Content Rule | Default Attributes |
 |-----------|------------------|-------------------|
-| **Belief** | `humanize(relation) + " " + object` | `subject`, `confidence`? |
+| **Fact** | `humanize(relation) + " " + object` | `subject`, `confidence`? |
 | **Event** | `content` | `role`, `time`? |
 | **Goal** | `object` (the objective description) | `subject`, `state`?, `deadline`? |
-| **Action** | `object` (tool result summary) | `tool`, `phase`? |
+| **Tool** | `object` (tool result summary) | `tool`, `phase`? |
 | **Observation** | `object` (what was observed) | `observer`? |
 | **Reasoning** | `conclusion` | `type`? |
 | **State** | `plan` (summary) | `context`? |
@@ -1350,7 +1350,7 @@ Full ISO 8601 timestamps remain in the machine envelope. Implementations MAY pro
 The `PROJECT` clause overrides default content projection, allowing queries to surface custom or domain-specific fields:
 
 ```sql
-CAL/1 RECALL beliefs ABOUT "alice"
+CAL/1 RECALL facts ABOUT "alice"
   PROJECT content(relation, object), attr(confidence, x_department)
   LIMIT 10 AS sml
 ```
@@ -1463,7 +1463,7 @@ CAL/1 DEFINE TEMPLATE semantic_sml
 ```sql
 CAL/1 ASSEMBLE conversation_context
   FOR "helping alice with her project"
-  FROM beliefs: (RECALL beliefs ABOUT "alice" LIMIT 20),
+  FROM beliefs: (RECALL facts ABOUT "alice" LIMIT 20),
        goals: (RECALL goals ABOUT "alice" RECENT 5)
   BUDGET 3000 tokens
   FORMAT TEMPLATE semantic_sml
@@ -1482,9 +1482,9 @@ FORMAT TEMPLATE {
 ```sml
 <context intent="helping alice prepare her Q1 engineering review">
 
-  <belief subject="alice" confidence="0.95">prefers dark mode in all tools</belief>
-  <belief subject="alice" confidence="0.88">requires keyboard shortcuts for productivity</belief>
-  <belief subject="alice" confidence="0.82">works best in deep-focus blocks of 90 minutes</belief>
+  <fact subject="alice" confidence="0.95">prefers dark mode in all tools</fact>
+  <fact subject="alice" confidence="0.88">requires keyboard shortcuts for productivity</fact>
+  <fact subject="alice" confidence="0.82">works best in deep-focus blocks of 90 minutes</fact>
 
   <goal subject="alice" state="active" deadline="2026-03-15">complete Q1 engineering review presentation</goal>
   <goal subject="alice" state="active">reduce P0 incident rate by 20% in Q2</goal>
@@ -1493,8 +1493,8 @@ FORMAT TEMPLATE {
   <event role="assistant" time="10m ago">Sure — retrieving deployment counts, incident data, and velocity now.</event>
   <event role="user" time="8m ago">Focus on the reliability numbers first.</event>
 
-  <action tool="query_metrics" phase="completed">retrieved 47 deployments and 3 P0 incidents for Q1 2026</action>
-  <action tool="search_docs" phase="completed">found Q1 review template in confluence/engineering/reviews</action>
+  <tool tool="query_metrics" phase="completed">retrieved 47 deployments and 3 P0 incidents for Q1 2026</tool>
+  <tool tool="search_docs" phase="completed">found Q1 review template in confluence/engineering/reviews</tool>
 
   <observation observer="system">alice opened incident-dashboard at 09:14 UTC</observation>
   <observation observer="system" source="calendar">Q1 review presentation scheduled for 2026-03-15 14:00 UTC</observation>
@@ -1556,7 +1556,7 @@ TOON is complementary to SML, not a replacement:
 
 | Property | SML | TOON |
 |----------|-----|------|
-| Semantic tag names | Yes (`<belief>`, `<goal>`, …) | No — grain type in section header only |
+| Semantic tag names | Yes (`<fact>`, `<goal>`, …) | No — grain type in section header only |
 | Token efficiency | Moderate | High (~40% fewer vs JSON) |
 | Uniform arrays | One element per line | CSV table — optimal |
 | Mixed grain types | Natural (each type has its own tag) | Grouped sections |
@@ -1612,7 +1612,7 @@ Where:
 At `summary` disclosure, `confidence`, `state`, `phase`, and `type` columns are omitted.
 At `full` disclosure, additional columns `source` and `observed` are appended.
 
-**Example — `RECALL beliefs ABOUT "alice" LIMIT 3 AS toon`:**
+**Example — `RECALL facts ABOUT "alice" LIMIT 3 AS toon`:**
 ```
 beliefs[3]{subject,content,confidence}:
 alice,prefers dark mode,0.95
@@ -1753,7 +1753,7 @@ assembly_started
 
 ```sql
 ASSEMBLE user_context
-  FROM beliefs: (RECALL beliefs ABOUT "alice")
+  FROM beliefs: (RECALL facts ABOUT "alice")
   BUDGET 2000 tokens
   STREAM { all }                              -- all events
   -- or: STREAM { progress, chunks }          -- specific events
@@ -1852,7 +1852,7 @@ OMS defines domain profiles (healthcare, legal, finance, robotics, science, cons
 
 ```sql
 RECALL WHERE tags INCLUDE ["profile:healthcare"]
-RECALL beliefs WHERE tags INCLUDE ["profile:healthcare"]
+RECALL facts WHERE tags INCLUDE ["profile:healthcare"]
   AND subject = "patient:P-12345" AND relation IS PREFERENCE
 ```
 
@@ -1872,7 +1872,7 @@ Domain-specific fields use OMS domain prefix convention:
 
 **Example:**
 ```sql
-RECALL beliefs WHERE tags INCLUDE ["profile:healthcare"]
+RECALL facts WHERE tags INCLUDE ["profile:healthcare"]
   AND hc:patient_id = "P-12345"
   AND hc:condition_code IN ("J06.9", "J20.9")
   AND relation = "mg:knows"
@@ -1936,8 +1936,8 @@ A formatted representation for direct insertion into LLM context windows. The co
 ```sml
 <context intent="helping alice with project">
 
-  <belief subject="alice" confidence="0.92">prefers dark mode</belief>
-  <belief subject="alice" confidence="0.88">requires keyboard shortcuts</belief>
+  <fact subject="alice" confidence="0.92">prefers dark mode</fact>
+  <fact subject="alice" confidence="0.88">requires keyboard shortcuts</fact>
 
   <goal subject="alice" state="active">complete Q1 review</goal>
 
@@ -1948,7 +1948,7 @@ A formatted representation for direct insertion into LLM context windows. The co
 ```markdown
 ## Context: helping alice with project
 
-**Beliefs**
+**Facts**
 - alice prefers dark mode (confidence: 0.92)
 - alice requires keyboard shortcuts (confidence: 0.88)
 
@@ -1958,8 +1958,8 @@ A formatted representation for direct insertion into LLM context windows. The co
 
 **Compact format** (for `compact` / `text`):
 ```
-[belief] alice prefers dark mode (0.92)
-[belief] alice requires keyboard shortcuts (0.88)
+[fact] alice prefers dark mode (0.92)
+[fact] alice requires keyboard shortcuts (0.88)
 [goal] alice: complete Q1 review (active)
 ```
 
@@ -1978,7 +1978,7 @@ When the query specifies a format list (`FORMAT [markdown, json]`), the response
     "duration_ms": 38
   },
   "formats": {
-    "markdown": "## Beliefs\n- alice prefers dark mode (confidence: 0.92)\n",
+    "markdown": "## Facts\n- alice prefers dark mode (confidence: 0.92)\n",
     "json": [
       {"subject": "alice", "relation": "prefers", "object": "dark mode", "confidence": 0.92}
     ]
@@ -2020,10 +2020,10 @@ Each grain type projects its fields into a **text content** string and **attribu
 
 | Grain Type | Projected Text Content | Example Output (sml) |
 |-----------|----------------------|---------------------|
-| Belief | `humanize(relation) + " " + object` | `<belief subject="alice" confidence="0.95">prefers dark mode in all tools</belief>` |
+| Fact | `humanize(relation) + " " + object` | `<fact subject="alice" confidence="0.95">prefers dark mode in all tools</fact>` |
 | Event | `content` | `<event role="user" time="10m ago">Can you help me pull together the Q1 metrics?</event>` |
 | Goal | `object` | `<goal subject="alice" state="active" deadline="2026-03-15">complete Q1 engineering review presentation</goal>` |
-| Action | `object` (tool result) | `<action tool="query_metrics" phase="completed">retrieved 47 deployments and 3 P0 incidents for Q1 2026</action>` |
+| Tool | `object` (tool result) | `<tool tool="query_metrics" phase="completed">retrieved 47 deployments and 3 P0 incidents for Q1 2026</tool>` |
 | Observation | `object` | `<observation observer="system">alice opened incident-dashboard at 09:14 UTC</observation>` |
 | Reasoning | `conclusion` | `<reasoning type="deductive">alice is prioritising reliability given 3 P0 incidents; lead with incident reduction narrative</reasoning>` |
 | State | `plan` summary | `<state context="q1_review_prep">outlining slides: 1. headline metrics  2. incident retrospective  3. velocity trend  4. Q2 goals</state>` |
@@ -2050,7 +2050,7 @@ Every valid CAL statement has exactly one representation in each format, and con
 
 **text/cal:**
 ```
-CAL/1 RECALL beliefs ABOUT "alice" WHERE confidence >= 0.8 RECENT 5 AS markdown
+CAL/1 RECALL facts ABOUT "alice" WHERE confidence >= 0.8 RECENT 5 AS markdown
 ```
 
 **application/json+cal:**
@@ -2116,7 +2116,7 @@ Implementations MUST declare cross-lingual capability in `DESCRIBE capabilities`
 Default: Unicode code point order (binary sort). Locale-aware sorting requested via `WITH locale("xx")`:
 
 ```sql
-RECALL beliefs ABOUT "alice" ORDER BY object ASC WITH locale("de")
+RECALL facts ABOUT "alice" ORDER BY object ASC WITH locale("de")
 ```
 
 Locale-aware sorting is optional. Implementations that do not support it MUST ignore the `locale()` option with a warning.
@@ -2247,7 +2247,7 @@ CAL String (ADD, SUPERSEDE, or REVERT)
   "issued_at": 1709337600000,
   "expires_at": 1709337900000,
   "max_uses": 1,
-  "allowed_grain_types": ["belief"],
+  "allowed_grain_types": ["fact"],
   "write_quota_remaining": 10,
   "signature": "hmac-sha256-signature"
 }
@@ -2400,9 +2400,9 @@ Errors are stable across spec versions. Every error MUST include: code, message,
     "code": "CAL-E003",
     "message": "Unknown grain type \"fact\".",
     "position": {"start": 7, "end": 11, "line": 1, "col": 8},
-    "suggestion": "Did you mean \"belief\"? (OMS renamed Fact -> Belief in v1.2)",
-    "example": "RECALL beliefs WHERE subject = \"alice\"",
-    "valid_values": ["belief","event","state","workflow","action","observation","goal","reasoning","consensus","consent"]
+    "suggestion": "Did you mean \"fact\"? (OMS renamed Belief -> Fact in v1.4)",
+    "example": "RECALL facts WHERE subject = \"alice\"",
+    "valid_values": ["fact","event","state","workflow","tool","observation","goal","reasoning","consensus","consent"]
   }
 }
 ```
@@ -2615,7 +2615,7 @@ It can read, assemble, and evolve memories, but never delete them.
   time BETWEEN epoch1 AND epoch2  -- epoch range
   confidence >= 0.8               -- min confidence
   tags INCLUDE ["tag1"]           -- required tags
-  type = "belief"                 -- grain type
+  type = "fact"                 -- grain type
 
 ### Shortcuts: ABOUT, RECENT n, SINCE, LIKE, MY, CONTRADICTIONS, BETWEEN
 
@@ -2638,7 +2638,7 @@ It can read, assemble, and evolve memories, but never delete them.
   FORMAT [TEMPLATE "{{subject}}" AS names, TEMPLATE "{{object}}" AS values]
 
 ### Output formats:
-  sml (default structured): flat tag-based — <belief subject="alice" confidence="0.92">prefers dark mode</belief>
+  sml (default structured): flat tag-based — <fact subject="alice" confidence="0.92">prefers dark mode</fact>
   toon: CSV-tabular, ~40% fewer tokens — beliefs[3]{subject,content,confidence}:\nalice,prefers dark mode,0.95
   markdown: human-readable prose
   json: machine-readable structured data
@@ -2712,7 +2712,7 @@ All error codes use the `CAL-E` prefix.
 |------|-------------|
 | CAL-E020 | Incompatible types in comparison |
 | CAL-E021 | Pipeline stage type mismatch |
-| CAL-E022 | SUBJECTS/OBJECTS requires belief-type input |
+| CAL-E022 | SUBJECTS/OBJECTS requires fact-type input |
 
 ### Execution Errors (CAL-E030 -- CAL-E031)
 
@@ -2727,13 +2727,13 @@ All error codes use the `CAL-E` prefix.
 |------|-------------|
 | CAL-E040 | SupersessionConflict -- target grain already superseded |
 | CAL-E041 | NoPreviousVersion -- REVERT target is the original grain |
-| CAL-E042 | GrainTypeNotEvolvable -- only Belief grains can be superseded |
+| CAL-E042 | GrainTypeNotEvolvable -- only Fact grains can be superseded |
 | CAL-E043 | WriteQuotaExceeded -- too many evolve operations |
 | CAL-E044 | Tier1NotEnabled -- requires Tier 1 capability |
 | CAL-E045 | NamespaceMismatch -- target grain in different namespace |
 | CAL-E046 | TargetNotFound -- target hash does not exist |
 | CAL-E050 | MissingRequiredField -- ADD requires subject, relation, object |
-| CAL-E051 | GrainTypeNotAddable -- only Belief, Observation, Goal can be created |
+| CAL-E051 | GrainTypeNotAddable -- only Fact, Observation, Goal can be created |
 | CAL-E052 | AddQuotaExceeded -- too many ADD operations |
 
 ### Multi-Format Errors (CAL-E110, CAL-E113)
@@ -2749,7 +2749,7 @@ All error codes use the `CAL-E` prefix.
 |------|-------------|
 | CAL-E060 | AmbiguousShortcut / FieldNotOnGrainType |
 | CAL-E061 | Grain-type-specific field used without declaring grain type |
-| CAL-E062 | Invalid `action_phase` value |
+| CAL-E062 | Invalid `tool_phase` value |
 | CAL-E063 | Invalid `goal_state` value |
 | CAL-E064 | Invalid `consent_action` value |
 | CAL-E065 | Invalid `recall_priority` value |
@@ -2892,10 +2892,10 @@ CHUNK, PAUSE, RESUME, CANCEL
 | Workflow | `trigger` | String | `=`, `!=` |
 | Workflow | `node` | String | `=` |
 | Workflow | `binding` | String | `=` |
-| Action | `tool_name` | String | `=`, `!=`, `IN` |
-| Action | `action_phase` | String | `=` |
-| Action | `is_error` | Boolean | `=` |
-| Action | `tool_call_id` | String | `=` |
+| Tool | `tool_name` | String | `=`, `!=`, `IN` |
+| Tool | `tool_phase` | String | `=` |
+| Tool | `is_error` | Boolean | `=` |
+| Tool | `tool_call_id` | String | `=` |
 | Observation | `observer_id` | String | `=`, `!=` |
 | Observation | `observer_type` | String | `=`, `!=` |
 | Goal | `goal_state` | String | `=`, `!=` |
@@ -2938,7 +2938,7 @@ CHUNK, PAUSE, RESUME, CANCEL
 
 ---
 
-**Document Status:** This is the CAL (Context Assembly Language) Specification v1.0. It defines a non-destructive, deterministic, LLM-native context assembly and evolution language for OMS-compliant memory databases. CAL is part of the Open Memory Specification (OMS) v1.3 — see [SPECIFICATION.md](./SPECIFICATION.md).
+**Document Status:** This is the CAL (Context Assembly Language) Specification v1.0. It defines a non-destructive, deterministic, LLM-native context assembly and evolution language for OMS-compliant memory databases. CAL is part of the Open Memory Specification (OMS) v1.4 — see [SPECIFICATION.md](./SPECIFICATION.md).
 
 **Last Updated:** 2026-03-05
 **License:** This specification is offered under the Open Web Foundation Final Specification Agreement (OWFa 1.0)

--- a/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
+++ b/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
@@ -824,7 +824,7 @@ CAL defines **relation category shortcuts** as syntactic sugar for common multi-
 **Examples:**
 
 ```sql
--- All preference-related beliefs about alice
+-- All preference-related facts about alice
 RECALL facts WHERE subject = "alice" AND relation IS PREFERENCE
   ORDER BY confidence DESC
 
@@ -901,14 +901,14 @@ The flagship new statement. Composes a context block from multiple RECALL source
 CAL/1 ASSEMBLE user_context
   FOR "conversation about alice's preferences and goals"
   FROM
-    beliefs:  (RECALL facts ABOUT "alice" WHERE relation = "prefers" LIMIT 20),
+    facts:    (RECALL facts ABOUT "alice" WHERE relation = "prefers" LIMIT 20),
     goals:    (RECALL goals ABOUT "alice" RECENT 10),
     events:   (RECALL events WHERE user_id = "alice" RECENT 5),
     history:  (RECALL facts ABOUT "alice"
                 WHERE relation = "prefers" WITH superseded
                 ORDER BY time DESC LIMIT 3)
   BUDGET 2000 tokens
-  PRIORITY beliefs > goals > events > history
+  PRIORITY facts > goals > events > history
   FORMAT markdown
   WITH progressive_disclosure, dedup(subject)
 ```
@@ -976,7 +976,7 @@ Returns the execution plan without running the query. Works with all statement t
 EXPLAIN RECALL facts WHERE query = "alice preferences" LIMIT 10
 EXPLAIN ASSEMBLE user_context
   FOR "conversation about alice"
-  FROM beliefs: (RECALL facts ABOUT "alice"),
+  FROM facts: (RECALL facts ABOUT "alice"),
        goals: (RECALL goals ABOUT "alice" RECENT 5)
   BUDGET 2000 tokens
 ```
@@ -1090,7 +1090,7 @@ ADD workflow "release pipeline"
 
 **Structural inference:** Node types are inferred from graph topology — a node with multiple unconditional outgoing edges is a fork, a node receiving multiple edges is an AND-join, a node with `WHEN` edges is a decision point.
 
-**BIND clause:** Maps a node name to an Tool definition grain hash (`tool_phase: "definition"`). The executor fetches the definition to discover `tool_name`, `input_schema`, etc. Unbound nodes are resolved by name convention or treated as abstract steps.
+**BIND clause:** Maps a node name to a Tool definition grain hash (`tool_phase: "definition"`). The executor fetches the definition to discover `tool_name`, `input_schema`, etc. Unbound nodes are resolved by name convention or treated as abstract steps.
 
 **Node names:** Bare identifiers (`build`, `unit_test`) or quoted strings (`"send welcome email"`). Reserved words (`ADD`, `workflow`, `ON`, `WHEN`, `BIND`, `REASON`, `BECAUSE`) must be quoted.
 
@@ -1496,7 +1496,7 @@ CAL/1 DEFINE TEMPLATE semantic_sml
 ```sql
 CAL/1 ASSEMBLE conversation_context
   FOR "helping alice with her project"
-  FROM beliefs: (RECALL facts ABOUT "alice" LIMIT 20),
+  FROM facts: (RECALL facts ABOUT "alice" LIMIT 20),
        goals: (RECALL goals ABOUT "alice" RECENT 5)
   BUDGET 3000 tokens
   FORMAT TEMPLATE semantic_sml
@@ -1789,7 +1789,7 @@ assembly_started
 
 ```sql
 ASSEMBLE user_context
-  FROM beliefs: (RECALL facts ABOUT "alice")
+  FROM facts: (RECALL facts ABOUT "alice")
   BUDGET 2000 tokens
   STREAM { all }                              -- all events
   -- or: STREAM { progress, chunks }          -- specific events
@@ -2434,11 +2434,11 @@ Errors are stable across spec versions. Every error MUST include: code, message,
 {
   "error": {
     "code": "CAL-E003",
-    "message": "Unknown grain type \"fact\".",
-    "position": {"start": 7, "end": 11, "line": 1, "col": 8},
+    "message": "Unknown grain type \"belief\".",
+    "position": {"start": 7, "end": 13, "line": 1, "col": 8},
     "suggestion": "Did you mean \"fact\"? (OMS renamed Belief -> Fact in v1.4)",
     "example": "RECALL facts WHERE subject = \"alice\"",
-    "valid_values": ["fact","event","state","workflow","tool","observation","goal","reasoning","consensus","consent"]
+    "valid_values": ["fact","event","state","workflow","tool","observation","goal","reasoning","consensus","consent","skill"]
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ OMS is an open standard for portable, auditable, and interoperable agent memory.
 
 ## OMS — The Memory Format
 
-OMS defines the **Memory Grain (`.mg`) container** — a binary format for immutable, content-addressed knowledge units called *grains*. A memory grain is the atomic unit of agent knowledge: a single immutable belief, event, observation, or decision record, identified by the SHA-256 hash of its canonical binary representation.
+OMS defines the **Memory Grain (`.mg`) container** — a binary format for immutable, content-addressed knowledge units called *grains*. A memory grain is the atomic unit of agent knowledge: a single immutable fact, event, observation, or decision record, identified by the SHA-256 hash of its canonical binary representation.
 
 Think of the `.mg` container as what JSON is to APIs or `.git` objects are to version control — a universal, language-agnostic, self-describing interchange format for agent memory.
 
@@ -38,7 +38,7 @@ Think of the `.mg` container as what JSON is to APIs or `.git` objects are to ve
 
 | Type | Byte | Description |
 |------|------|-------------|
-| Belief | `0x01` | Declarative knowledge: subject–relation–object triple |
+| Fact | `0x01` | Declarative knowledge: subject–relation–object triple |
 | Event | `0x02` | Timestamped occurrence: message, interaction, or utterance |
 | State | `0x03` | Agent state snapshot at a point in time |
 | Workflow | `0x04` | Directed graph of procedural steps |
@@ -108,7 +108,7 @@ A support agent handles an inbound ticket: *"My invoice shows a charge I don't r
 CAL/1 ASSEMBLE support_context
   FOR "resolving billing dispute for customer:priya"
   FROM
-    profile:   (RECALL beliefs  ABOUT "customer:priya"
+    profile:   (RECALL facts  ABOUT "customer:priya"
                 WHERE relation IS KNOWLEDGE
                 LIMIT 10),
     history:   (RECALL events
@@ -119,7 +119,7 @@ CAL/1 ASSEMBLE support_context
                 WHERE subject = "customer:priya"
                   AND tags INCLUDE ["support:billing"]
                 RECENT 5),
-    policy:    (RECALL beliefs
+    policy:    (RECALL facts
                 WHERE tags INCLUDE ["policy:billing"]
                 LIMIT 5),
     session:   (RECALL actions
@@ -160,13 +160,13 @@ CAL/1 RECALL workflows
 
 ## SML — Semantic Markup Language
 
-SML is the output format produced by CAL `ASSEMBLE FORMAT sml`. It is a **flat, tag-based markup format** designed for direct LLM consumption. Tag names are OMS grain types (`<belief>`, `<event>`, `<reasoning>`, …). The tag tells the LLM the epistemic status of the content; the attributes carry decision metadata; the element text is natural-language prose.
+SML is the output format produced by CAL `ASSEMBLE FORMAT sml`. It is a **flat, tag-based markup format** designed for direct LLM consumption. Tag names are OMS grain types (`<fact>`, `<event>`, `<reasoning>`, …). The tag tells the LLM the epistemic status of the content; the attributes carry decision metadata; the element text is natural-language prose.
 
 SML is **not XML**. It requires no parser, no schema, no escape sequences. An LLM reads it the same way a person reads a well-structured document.
 
 ### Structural Rules
 
-1. **Tag names are grain types.** `<belief>`, `<goal>`, `<event>`, `<action>`, `<observation>`, `<reasoning>`, `<state>`, `<workflow>`, `<consensus>`, `<consent>` — no others.
+1. **Tag names are grain types.** `<fact>`, `<goal>`, `<event>`, `<action>`, `<observation>`, `<reasoning>`, `<state>`, `<workflow>`, `<consensus>`, `<consent>` — no others.
 2. **Flat only.** No nesting beyond the `<context>` envelope.
 3. **No storage internals.** No hashes, namespaces, or OMS metadata in the output.
 4. **Natural language content.** Element text is prose, not decomposed triples.
@@ -179,9 +179,9 @@ This is the SML block injected into the LLM system prompt for the billing disput
 ```sml
 <context intent="resolving billing dispute for customer:priya">
 
-  <belief subject="customer:priya" confidence="0.97">account tier is Professional, annual billing cycle</belief>
-  <belief subject="customer:priya" confidence="0.93">primary contact email is priya@example.com</belief>
-  <belief subject="customer:priya" confidence="0.89">enrolled in auto-renewal since 2024-03-01</belief>
+  <fact subject="customer:priya" confidence="0.97">account tier is Professional, annual billing cycle</fact>
+  <fact subject="customer:priya" confidence="0.93">primary contact email is priya@example.com</fact>
+  <fact subject="customer:priya" confidence="0.89">enrolled in auto-renewal since 2024-03-01</fact>
 
   <event role="user"  time="2m ago">My invoice shows a charge I don't recognise — $299 on 28 Feb.</event>
   <event role="agent" time="2m ago">Looking into that now, Priya. Retrieving your billing history.</event>
@@ -199,7 +199,7 @@ This is the SML block injected into the LLM system prompt for the billing disput
   <reasoning type="deductive">charge is the annual plan renewal; customer enrolled in auto-renewal; charge is valid</reasoning>
   <reasoning type="abductive">customer may be unaware of annual cycle because last billing interaction was January — explain renewal cadence before offering monthly switch</reasoning>
 
-  <belief subject="policy:billing" confidence="1.0">customers may switch billing cycle within 30 days of renewal with pro-rated refund</belief>
+  <fact subject="policy:billing" confidence="1.0">customers may switch billing cycle within 30 days of renewal with pro-rated refund</fact>
 
   <consent action="granted" grantor="customer:priya" grantee="support-agent">access billing records and invoice history for dispute resolution</consent>
 
@@ -214,9 +214,9 @@ SML metadata density is controlled by disclosure level — the element shape nev
 
 | Level | Example |
 |-------|---------|
-| `summary` | `<belief subject="customer:priya">enrolled in auto-renewal</belief>` |
-| `standard` | `<belief subject="customer:priya" confidence="0.89">enrolled in auto-renewal since 2024-03-01</belief>` |
-| `full` | `<belief subject="customer:priya" confidence="0.89" source="crm" observed="14d ago">enrolled in auto-renewal since 2024-03-01</belief>` |
+| `summary` | `<fact subject="customer:priya">enrolled in auto-renewal</fact>` |
+| `standard` | `<fact subject="customer:priya" confidence="0.89">enrolled in auto-renewal since 2024-03-01</fact>` |
+| `full` | `<fact subject="customer:priya" confidence="0.89" source="crm" observed="14d ago">enrolled in auto-renewal since 2024-03-01</fact>` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Think of the `.mg` container as what JSON is to APIs or `.git` objects are to ve
 | Reasoning | `0x08` | Inference chain and thought audit trail |
 | Consensus | `0x09` | Multi-agent agreement record |
 | Consent | `0x0A` | DID-scoped permission grant or withdrawal |
+| Skill | `0x0B` | Packaged, reusable agent capability: definition plus optional learned proficiency |
 | `0xF0–0xFF` | — | Application-defined domain profile types |
 
 ### Blob Layout
@@ -166,7 +167,7 @@ SML is **not XML**. It requires no parser, no schema, no escape sequences. An LL
 
 ### Structural Rules
 
-1. **Tag names are grain types.** `<fact>`, `<goal>`, `<event>`, `<tool>`, `<observation>`, `<reasoning>`, `<state>`, `<workflow>`, `<consensus>`, `<consent>` — no others.
+1. **Tag names are grain types.** `<fact>`, `<goal>`, `<event>`, `<tool>`, `<observation>`, `<reasoning>`, `<state>`, `<workflow>`, `<consensus>`, `<consent>`, `<skill>` — no others.
 2. **Flat only.** No nesting beyond the `<context>` envelope.
 3. **No storage internals.** No hashes, namespaces, or OMS metadata in the output.
 4. **Natural language content.** Element text is prose, not decomposed triples.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Memory Specification (OMS)
 
-**Version:** 1.3 | **Status:** Standards Track | **License:** CC0 1.0 Universal (Public Domain)
+**Version:** 1.4 | **Status:** Standards Track | **License:** CC0 1.0 Universal (Public Domain)
 
 Backed by [areev.ai](https://areev.ai).
 
@@ -42,7 +42,7 @@ Think of the `.mg` container as what JSON is to APIs or `.git` objects are to ve
 | Event | `0x02` | Timestamped occurrence: message, interaction, or utterance |
 | State | `0x03` | Agent state snapshot at a point in time |
 | Workflow | `0x04` | Directed graph of procedural steps |
-| Action | `0x05` | Tool invocation or code execution |
+| Tool | `0x05` | Tool invocation or code execution |
 | Observation | `0x06` | Sensor or cognitive input |
 | Goal | `0x07` | Intent, objective, or desired outcome |
 | Reasoning | `0x08` | Inference chain and thought audit trail |
@@ -122,7 +122,7 @@ CAL/1 ASSEMBLE support_context
     policy:    (RECALL facts
                 WHERE tags INCLUDE ["policy:billing"]
                 LIMIT 5),
-    session:   (RECALL actions
+    session:   (RECALL tools
                 WHERE session_id = "sess-20260303-priya"
                 LIMIT 10)
   BUDGET 4000 tokens
@@ -166,7 +166,7 @@ SML is **not XML**. It requires no parser, no schema, no escape sequences. An LL
 
 ### Structural Rules
 
-1. **Tag names are grain types.** `<fact>`, `<goal>`, `<event>`, `<action>`, `<observation>`, `<reasoning>`, `<state>`, `<workflow>`, `<consensus>`, `<consent>` — no others.
+1. **Tag names are grain types.** `<fact>`, `<goal>`, `<event>`, `<tool>`, `<observation>`, `<reasoning>`, `<state>`, `<workflow>`, `<consensus>`, `<consent>` — no others.
 2. **Flat only.** No nesting beyond the `<context>` envelope.
 3. **No storage internals.** No hashes, namespaces, or OMS metadata in the output.
 4. **Natural language content.** Element text is prose, not decomposed triples.
@@ -190,8 +190,8 @@ This is the SML block injected into the LLM system prompt for the billing disput
 
   <workflow trigger="billing_dispute_opened" state="open">verify_charge -> check_renewal_date -> explain_or_escalate -> offer_billing_cycle_change -> close_ticket</workflow>
 
-  <action tool="get_invoice"    phase="completed">retrieved invoice INV-2026-02-28: $299 annual Professional plan renewal</action>
-  <action tool="get_plan_history" phase="completed">plan enrolled 2024-03-01, renewed annually; last renewal 2026-02-28</action>
+  <tool tool="get_invoice"    phase="completed">retrieved invoice INV-2026-02-28: $299 annual Professional plan renewal</tool>
+  <tool tool="get_plan_history" phase="completed">plan enrolled 2024-03-01, renewed annually; last renewal 2026-02-28</tool>
 
   <observation observer="billing-system">renewal processed automatically on 2026-02-28 at 00:01 UTC; no failed payment</observation>
   <observation observer="system">customer last viewed billing page 2026-01-15</observation>

--- a/SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md
+++ b/SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md
@@ -10,7 +10,7 @@
 - [Abstract](#abstract)
 1. [What is SML?](#1-what-is-sml)
 2. [Structural Rules](#2-structural-rules)
-3. [Comprehensive Example — All 10 Grain Types](#3-comprehensive-example--all-10-grain-types)
+3. [Comprehensive Example — All 11 Grain Types](#3-comprehensive-example--all-11-grain-types)
 4. [Progressive Disclosure](#4-progressive-disclosure)
 - [Appendix A: Relationship to CAL](#appendix-a-relationship-to-cal)
 
@@ -57,7 +57,7 @@ The formatted output uses a **flat, semantic structure**:
 
 ---
 
-## 3. Comprehensive Example — All 10 Grain Types
+## 3. Comprehensive Example — All 11 Grain Types
 
 The following example shows a single assembled context covering every grain type. The scenario: an agent helping alice prepare her Q1 engineering review.
 
@@ -92,10 +92,12 @@ The following example shows a single assembled context covering every grain type
 
   <consent action="granted" grantor="alice" grantee="agent">access engineering metrics dashboards for review preparation</consent>
 
+  <skill name="metrics_review" proficiency="0.82" domain="software">summarise quarterly engineering metrics and surface the reliability narrative</skill>
+
 </context>
 ```
 
-Each element maps directly to one grain type. The LLM reads the tag to understand the epistemic status of the content — a `<fact>` carries a known confidence, a `<reasoning>` signals inference, a `<consent>` signals an explicit permission grant — without needing to parse attribute schemas or understand OMS internals.
+Each element maps directly to one grain type. The LLM reads the tag to understand the epistemic status of the content — a `<fact>` carries a known confidence, a `<reasoning>` signals inference, a `<consent>` signals an explicit permission grant, a `<skill>` signals a packaged, reusable capability — without needing to parse attribute schemas or understand OMS internals.
 
 ---
 

--- a/SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md
+++ b/SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md
@@ -1,7 +1,7 @@
 # SML (Semantic Markup Language) Specification v1.0
 
 **Status:** Standards Track | **Date:** 2026-03-03 | **Version:** 1.0 | **Classification:** Experimental
-**Part of:** [Open Memory Specification (OMS) v1.3](./SPECIFICATION.md)
+**Part of:** [Open Memory Specification (OMS) v1.4](./SPECIFICATION.md)
 
 ---
 
@@ -22,7 +22,7 @@
 
 SML uses tag syntax as a **semantic signalling device** — the tag name tells the LLM what kind of information follows (using OMS grain types as tag names), the attributes carry lightweight decision metadata, and the element text is natural language content.
 
-SML is part of the [Open Memory Specification (OMS) v1.3](./SPECIFICATION.md) family. The `FORMAT` system that produces SML output is defined in the [Context Assembly Language (CAL) specification](./CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md).
+SML is part of the [Open Memory Specification (OMS) v1.4](./SPECIFICATION.md) family. The `FORMAT` system that produces SML output is defined in the [Context Assembly Language (CAL) specification](./CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md).
 
 ---
 
@@ -32,7 +32,7 @@ SML is part of the [Open Memory Specification (OMS) v1.3](./SPECIFICATION.md) fa
 
 | Property | SML | Standard XML |
 |----------|-----|--------------|
-| Tag names | Grain type identifiers (`belief`, `goal`, `event`, …) | Arbitrary element names |
+| Tag names | Grain type identifiers (`fact`, `goal`, `event`, …) | Arbitrary element names |
 | Text content | Natural language prose, not decomposed triples | Structured data |
 | Attributes | Human-readable metadata hints (`confidence`, `state`, `time`) | Machine-parseable key-value pairs |
 | Nesting | **Flat only** — no nested elements (one `<context>` envelope only) | Arbitrary depth |
@@ -49,8 +49,8 @@ SML is the default format for the `structured` preset (alias `sml`) in CAL's [FO
 
 The formatted output uses a **flat, semantic structure**:
 
-1. **Tag names ARE the grain type.** No generic `<grain>` wrapper — use `<belief>`, `<goal>`, `<event>`, etc.
-2. **No group wrappers.** No `<source>`, `<beliefs>`, or other container elements. Whitespace separates grain groups.
+1. **Tag names ARE the grain type.** No generic `<grain>` wrapper — use `<fact>`, `<goal>`, `<event>`, etc.
+2. **No group wrappers.** No `<source>`, `<facts>`, or other container elements. Whitespace separates grain groups.
 3. **Storage internals never appear.** No hashes, counts, namespaces, or OMS-internal fields.
 4. **Text content reads as natural language.** The element text is the projected content, not decomposed triples.
 5. **One envelope element.** The `<context>` wrapper carries only the `intent` attribute. It is the sole container.
@@ -64,9 +64,9 @@ The following example shows a single assembled context covering every grain type
 ```sml
 <context intent="helping alice prepare her Q1 engineering review">
 
-  <belief subject="alice" confidence="0.95">prefers dark mode in all tools</belief>
-  <belief subject="alice" confidence="0.88">requires keyboard shortcuts for productivity</belief>
-  <belief subject="alice" confidence="0.82">works best in deep-focus blocks of 90 minutes</belief>
+  <fact subject="alice" confidence="0.95">prefers dark mode in all tools</fact>
+  <fact subject="alice" confidence="0.88">requires keyboard shortcuts for productivity</fact>
+  <fact subject="alice" confidence="0.82">works best in deep-focus blocks of 90 minutes</fact>
 
   <goal subject="alice" state="active" deadline="2026-03-15">complete Q1 engineering review presentation</goal>
   <goal subject="alice" state="active">reduce P0 incident rate by 20% in Q2</goal>
@@ -75,8 +75,8 @@ The following example shows a single assembled context covering every grain type
   <event role="assistant" time="10m ago">Sure — retrieving deployment counts, incident data, and velocity now.</event>
   <event role="user" time="8m ago">Focus on the reliability numbers first.</event>
 
-  <action tool="query_metrics" phase="completed">retrieved 47 deployments and 3 P0 incidents for Q1 2026</action>
-  <action tool="search_docs" phase="completed">found Q1 review template in confluence/engineering/reviews</action>
+  <tool tool="query_metrics" phase="completed">retrieved 47 deployments and 3 P0 incidents for Q1 2026</tool>
+  <tool tool="search_docs" phase="completed">found Q1 review template in confluence/engineering/reviews</tool>
 
   <observation observer="system">alice opened incident-dashboard at 09:14 UTC</observation>
   <observation observer="system" source="calendar">Q1 review presentation scheduled for 2026-03-15 14:00 UTC</observation>
@@ -95,7 +95,7 @@ The following example shows a single assembled context covering every grain type
 </context>
 ```
 
-Each element maps directly to one grain type. The LLM reads the tag to understand the epistemic status of the content — a `<belief>` carries a known confidence, a `<reasoning>` signals inference, a `<consent>` signals an explicit permission grant — without needing to parse attribute schemas or understand OMS internals.
+Each element maps directly to one grain type. The LLM reads the tag to understand the epistemic status of the content — a `<fact>` carries a known confidence, a `<reasoning>` signals inference, a `<consent>` signals an explicit permission grant — without needing to parse attribute schemas or understand OMS internals.
 
 ---
 
@@ -105,9 +105,9 @@ Progressive disclosure controls **metadata density on a flat structure**, not ne
 
 | Level | Example |
 |-------|---------|
-| `summary` | `<belief subject="alice">prefers dark mode</belief>` |
-| `standard` | `<belief subject="alice" confidence="0.92">prefers dark mode</belief>` |
-| `full` | `<belief subject="alice" confidence="0.92" source="explicit" observed="2d ago">prefers dark mode</belief>` |
+| `summary` | `<fact subject="alice">prefers dark mode</fact>` |
+| `standard` | `<fact subject="alice" confidence="0.92">prefers dark mode</fact>` |
+| `full` | `<fact subject="alice" confidence="0.92" source="explicit" observed="2d ago">prefers dark mode</fact>` |
 
 ---
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -144,7 +144,7 @@ OMS defines the wire format and grain semantics. Two companion specifications ar
 
 CAL is a non-destructive, deterministic, LLM-native language for assembling agent context from OMS memory stores. It answers the question: *"what should be in the agent's context window right now?"* Key properties:
 
-- Operates on all 10 OMS grain types (Fact, Event, State, Workflow, Tool, Observation, Goal, Reasoning, Consensus, Consent)
+- Operates on all 11 OMS grain types (Fact, Event, State, Workflow, Tool, Observation, Goal, Reasoning, Consensus, Consent, Skill)
 - Extends the OMS Store Protocol (§28.4) with a formal, structured query syntax
 - `ASSEMBLE` statements compose context from multiple grain sources within a token budget
 - Append-only: CAL writes create new grains via `put`; the language cannot delete or modify existing grains — this is enforced at the grammar level
@@ -207,7 +207,8 @@ Hexadecimal values are lowercase. Byte sequences are represented in hex with spa
 | 0x08 | **Reasoning** | Inference chain and thought audit trail |
 | 0x09 | **Consensus** | Multi-agent agreement record |
 | 0x0A | **Consent** | Permission grant or withdrawal — DID-scoped, purpose-bounded |
-| 0x0B–0xEF | Reserved | Future standard types |
+| 0x0B | **Skill** | Packaged, reusable agent capability — definition (how-to, tools, resources) plus optional learned proficiency |
+| 0x0C–0xEF | Reserved | Future standard types |
 | 0xF0–0xFF | Domain profile types | Application-defined per Appendix A domain profiles |
 
 **Bytes 3-4 — Namespace Hash:** First two bytes of SHA-256(namespace), encoded as `uint16` big-endian. Provides 65,536 routing buckets without deserialization. Full namespace string remains authoritative in payload. This field is a routing hint only and MUST NOT be used for security decisions (see §13.3, §20).
@@ -636,7 +637,30 @@ When a Goal or Fact grain uses the `mg:delegates_to` relation, the following fie
 | `context_grains` | `cgrains` | array[string] | Content addresses of grains to transfer as context to the delegatee. Enables session handoff: the delegator selects which grains the delegatee needs to continue. |
 | `return_to` | `retdid` | string | DID of the agent to return control to after the delegated task completes. |
 
-### 6.12 Compaction Rules
+### 6.12 Skill-Specific Fields
+
+> **Note:** `description` reuses the shared `desc` key (also used by Goal, §6.7). `holder_did` (`hdid`) identifies the agent that possesses the skill, distinct from the common `author_did` (`adid`) which records the grain's writer. Bundled binary/file payloads use the common `content_refs` field (`cr`, §6.1); `license` uses the common `lic` key.
+
+| Full Name | Short Key | Type | Group |
+|-----------|-----------|------|-------|
+| `name` | `skname` | string | definition |
+| `instructions` | `instr` | string | definition |
+| `when_to_use` | `wtu` | string | definition |
+| `version` | `sver` | string | definition |
+| `allowed_tools` | `atls` | array[string] | definition |
+| `resources` | `res` | array[string] | definition |
+| `dependencies` | `deps` | array[string] | definition |
+| `input_modalities` | `imod` | array[string] | definition |
+| `output_modalities` | `omod` | array[string] | definition |
+| `domain` | `dom` | string | definition |
+| `holder_did` | `hdid` | string | learned |
+| `proficiency` | `prof` | float64 | learned |
+| `practice_count` | `prcnt` | int | learned |
+| `last_practiced_at` | `lpa` | int64 | learned |
+| `strategies` | `strat` | array[map] | learned |
+| `transferable` | `xfer` | bool | learned |
+
+### 6.13 Compaction Rules
 
 - Serializers MUST replace full field names with short keys before encoding
 - Deserializers MUST replace short keys with full field names after decoding
@@ -727,7 +751,7 @@ Multi-modal content (images, audio, video, embeddings, sensor data) is reference
 
 ## 8. Grain Types
 
-The `type` byte (Byte 2 of the fixed header) encodes the **cognitive grain type** — the class of knowledge unit this grain represents. Ten standard types are defined.
+The `type` byte (Byte 2 of the fixed header) encodes the **cognitive grain type** — the class of knowledge unit this grain represents. Eleven standard types are defined.
 
 ### Standard `mg:` Relation Vocabulary
 
@@ -756,7 +780,7 @@ The `mg:` namespace is reserved for standard semantic relations. Applications de
 | `mg:handed_off_to` | Event | Session handoff event record (§28.7) |
 | `mg:depends_on` | Goal | Task dependency (distinct from `parent_goals` hierarchy) |
 | `mg:assigned_to` | Goal | Task assigned to agent for execution |
-| `mg:capable_of` | Fact | Learned skill with proficiency and strategies (§28.8 Skill Convention) |
+| `mg:capable_of` | Skill | Learned skill with proficiency and strategies (§8.11; legacy Fact convention retained for back-compat) |
 
 ### 8.1 Fact (type = 0x01)
 
@@ -1010,6 +1034,48 @@ A DID-scoped, purpose-bounded permission grant or withdrawal. Four of six indust
 3. A withdrawn Consent grain is NOT deleted — both grant and withdrawal are retained for audit.
 4. Default `invalidation_policy.mode` for Consent grains is `"soft_locked"`.
 5. The `processing_basis` common field (§6.1) on any grain carries the content address of the Consent grain that authorized its creation — enabling GDPR Art. 17 erasure cascade.
+
+### 8.11 Skill (type = 0x0B)
+
+A reusable, self-contained agent capability — the durable definition of *what a capability is and how to perform it*, plus optional records of *how well a given agent performs it*. A Skill grain is the unit an agent loads to acquire a capability: a name, a description of when to use it, the procedural instructions, the tools it may invoke, the resources it bundles, and the other skills it depends on. The same type also carries optional **learned-competence** fields (`proficiency`, `practice_count`, strategies) so an agent can record and improve its mastery of a skill over time.
+
+This type promotes the §28.8 Skill Convention (formerly a `Fact + mg:capable_of` pattern) to a first-class grain, following the precedent set by Consent (§8.10). Skill grains became performance-critical for authoring, discovery, and transfer across multi-agent deployments, where the `object`-map convention was semantically correct but impractical to query at scale.
+
+Where an Agent Capability Fact (§28.5, `mg:has_capability`) is a static identity card of what an agent *is built to do*, and a Workflow (§8.4) is a single fixed procedure, a Skill is a packaged, transferable capability — optionally adaptive and practiced.
+
+**Required fields:**
+- `type` = "skill"
+- `name` (string) — machine-readable skill identifier (e.g., `"code_review"`)
+- `description` (string) — human-readable summary of what the skill does and when to use it
+- `created_at` (int64, epoch ms)
+
+**Optional — definition fields** (the durable, shareable specification):
+- `instructions` (string) — the procedural body: how to perform the skill (the prose/markdown "skill body" an agent loads when applying it)
+- `when_to_use` (string) — natural-language activation cue describing the conditions under which the skill SHOULD be selected (a discovery and routing signal)
+- `version` (string) — opaque, skill-defined version string (e.g., `"2.1.0"`). Supersession by system time remains authoritative for "latest" (§5).
+- `allowed_tools` (array[string]) — content addresses or identifiers of Tool definition grains (§27.1) the skill is permitted to invoke
+- `resources` (array[string]) — content addresses of bundled resource grains the skill ships with (scripts, templates, reference files). Binary or large file payloads are carried via the common `content_refs` field (§6.1).
+- `dependencies` (array[string]) — content addresses of Skill grains that must be available before this skill is effective
+- `input_modalities` (array[string]) — what the skill operates on: `"text"`, `"image"`, `"code"`, `"audio"`. Open enum.
+- `output_modalities` (array[string]) — what the skill produces. Open enum.
+- `domain` (string) — domain context: `"software"`, `"research"`, `"healthcare"`, `"finance"`. Open enum.
+
+**Optional — learned-competence fields** (a particular agent's mastery; omit for a pure definition):
+- `holder_did` (string) — DID of the agent that holds and practices this skill
+- `proficiency` (float64, [0.0, 1.0]) — current mastery level
+- `practice_count` (int) — number of successful applications (mirrors `success_count` in §6.1)
+- `last_practiced_at` (int64, epoch ms) — most recent successful application
+- `strategies` (array[map]) — context-dependent approaches. Each entry: `{condition: string, workflow: string, description?: string}`, where `workflow` is the content address of a Workflow grain (§8.4).
+- `transferable` (bool) — if `true`, another agent MAY ingest this grain and its referenced grains to acquire the skill
+- All common fields from §6.1 (e.g., `license`, `structural_tags`, `context` for arbitrary metadata)
+
+**Normative rules:**
+1. A Skill grain MAY be a pure **definition** (no `holder_did`/`proficiency`) or a held **instance** that adds learned-competence fields. `name` + `description` are sufficient to define a skill.
+2. When present, `proficiency` SHOULD equal the grain's top-level `confidence`.
+3. Learned-competence improvement is recorded by supersession: each change in `proficiency` writes a new Skill grain that supersedes the prior one and increments `practice_count`. The supersession chain is the complete learning history; Skill grains are never mutated in place. Degradation (e.g., when `last_practiced_at` exceeds an implementation threshold) is likewise realized by a superseding grain with reduced proficiency, not a mutation.
+4. Each `strategies[].workflow` MUST be the content address of a Workflow grain (§8.4). Each `dependencies` entry MUST be the content address of a Skill grain. Each `allowed_tools` entry SHOULD reference a Tool definition grain (§27.1).
+5. When an agent acquires a transferable skill, it writes a new Skill grain that sets `derived_from` to the source grain's content address, preserves the originating agent in `origin_did`, sets its own `holder_did` and `author_did`, and (for learned skills) resets `proficiency` and `practice_count` to the acquiring agent's initial values (typically `0`).
+6. Skill grains SHOULD use the `"agent:skills"` namespace to enable efficient discovery queries (see §28.8).
 
 ---
 
@@ -1761,7 +1827,7 @@ Implementations MUST declare which level they support:
 - Deserialize version byte + canonical MessagePack payload
 - Compute and verify SHA-256 content addresses
 - Support field compaction (short keys → full names)
-- Support all ten standard grain types (0x01–0x0A) per §8 schemas
+- Support all eleven standard grain types (0x01–0x0B) per §8 schemas
 - Ignore unknown fields
 - Constant-time hash comparison
 
@@ -2912,45 +2978,55 @@ When Agent A transfers control of a conversation to Agent B, the handoff is reco
 3. Agent B ingests the referenced grains, validates the delegation scope, and continues with a new `run_id` but the same `session_id`.
 4. When Agent B completes its task, it writes a Goal grain with `goal_state: "satisfied"` linked via `derived_from` to the delegation grain, and control returns to the agent specified in `return_to`.
 
-### 28.8 Skill Convention
+### 28.8 Skill Lifecycle and Transfer
 
-Agents that learn reusable capabilities SHOULD represent them as Fact grains with `relation: "mg:capable_of"` and a structured `object` map. A skill grain captures what an agent can do, how well it can do it, and the procedural knowledge needed to transfer the capability to another agent.
+Skills are represented by the dedicated **Skill grain (type 0x0B, §8.11)**. A Skill grain is a packaged, reusable capability: its **definition** fields (instructions, when-to-use, tools, resources, dependencies) specify what the capability is and how to perform it, while its optional **learned-competence** fields (proficiency, practice count, strategies) record how well a particular agent performs it. This section defines the conventions for authoring, lifecycle, transfer, and discovery; §8.11 defines the type's fields and normative rules.
+
+> **History:** Earlier OMS revisions described a `Fact + mg:capable_of` *convention* — a Fact grain whose `object` map carried the skill fields. OMS 1.4 promotes that pattern to a first-class Skill grain type (§8.11), following the Consent (§8.10) precedent. The `mg:capable_of` relation is retained in the vocabulary for backward compatibility, but new skills SHOULD be written as Skill grains.
 
 **Distinction from related constructs:**
 
 | Construct | Grain type | What it captures |
 |---|---|---|
 | Agent Capability (§28.5) | Fact (`mg:has_capability`) | Static identity card — what the agent *is built to do* |
-| Skill (§28.8) | Fact (`mg:capable_of`) | Learned capability — what the agent *has learned to do*, with proficiency and strategies |
+| Skill (§8.11, §28.8) | Skill (0x0B) | Packaged, reusable capability — the definition (how-to, tools, resources) plus optional learned proficiency and strategies |
 | Workflow (§8.4) | Workflow | Fixed action sequence — a single procedure, not an adaptive capability |
 
-**Convention:**
+**Example Skill grain:**
 ```json
 {
-  "type": "fact",
-  "subject": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
-  "relation": "mg:capable_of",
-  "object": {
-    "name": "code_review",
-    "description": "Review code changes for correctness, style, and security issues",
-    "proficiency": 0.82,
-    "strategies": [
-      {
-        "condition": "security_focused",
-        "workflow": "mg:sha256:a1b2c3...",
-        "description": "OWASP-oriented review for auth and input handling code"
-      },
-      {
-        "condition": "style_focused",
-        "workflow": "mg:sha256:d4e5f6...",
-        "description": "Linting and convention compliance review"
-      }
-    ],
-    "prerequisites": ["mg:sha256:f7e8d9..."],
-    "practice_count": 47,
-    "last_practiced_at": 1711929600000,
-    "transferable": true
-  },
+  "type": "skill",
+  "name": "code_review",
+  "description": "Review code changes for correctness, style, and security issues",
+  "version": "2.1.0",
+
+  "instructions": "Read the diff, classify the change, then apply the matching strategy. Always check auth and input-handling paths first.",
+  "when_to_use": "a pull request or code diff needs review before merge",
+  "allowed_tools": ["mg:sha256:b0c1d2..."],
+  "resources": ["mg:sha256:c3d4e5..."],
+  "dependencies": ["mg:sha256:f7e8d9..."],
+  "domain": "software",
+  "input_modalities": ["code", "text"],
+  "output_modalities": ["text"],
+
+  "holder_did": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+  "proficiency": 0.82,
+  "practice_count": 47,
+  "last_practiced_at": 1711929600000,
+  "transferable": true,
+  "strategies": [
+    {
+      "condition": "security_focused",
+      "workflow": "mg:sha256:a1b2c3...",
+      "description": "OWASP-oriented review for auth and input handling code"
+    },
+    {
+      "condition": "style_focused",
+      "workflow": "mg:sha256:d4e5f6...",
+      "description": "Linting and convention compliance review"
+    }
+  ],
+
   "confidence": 0.82,
   "source_type": "agent_inferred",
   "namespace": "agent:skills",
@@ -2962,44 +3038,30 @@ Agents that learn reusable capabilities SHOULD represent them as Fact grains wit
 }
 ```
 
-The `object` map is an open schema. Standard keys:
+See §8.11 for the full field reference (required fields, optional fields, and compaction keys).
 
-| Key | Type | Description |
-|---|---|---|
-| `name` | string | Machine-readable skill identifier |
-| `description` | string | Human-readable summary of what the skill enables |
-| `proficiency` | float64, [0.0, 1.0] | Current mastery level. SHOULD equal the grain's top-level `confidence`. |
-| `strategies` | array[map] | Context-dependent approaches. Each entry: `{condition: string, workflow: string, description?: string}`. The `workflow` value is a content address of a Workflow grain (§8.4). |
-| `prerequisites` | array[string] | Content addresses of Skill Fact grains that must be acquired before this skill is effective |
-| `practice_count` | int | Number of successful applications (mirrors `success_count` in core fields) |
-| `last_practiced_at` | int64 | Epoch ms of most recent successful application |
-| `transferable` | bool | If `true`, another agent MAY ingest this grain and its referenced Workflow grains to acquire the skill |
-| `input_modalities` | array[string] | What the skill operates on: `"text"`, `"image"`, `"code"`, `"audio"`. Open enum. |
-| `output_modalities` | array[string] | What the skill produces |
-| `domain` | string | Domain context: `"software"`, `"research"`, `"healthcare"`, `"finance"`. Open enum. |
-
-**Namespace:** Skill Fact grains SHOULD use the `"agent:skills"` namespace to enable efficient discovery queries.
+**Namespace:** Skill grains SHOULD use the `"agent:skills"` namespace to enable efficient discovery queries.
 
 **Proficiency lifecycle:**
 
-1. **Acquisition.** When an agent first learns a capability, it writes a Skill Fact grain with an initial `proficiency` (typically low). The `derived_from` field SHOULD reference the grains (Events, Actions, Reasoning) that contributed to learning.
-2. **Improvement.** Each time proficiency changes, the agent supersedes the previous Skill Fact grain with an updated `proficiency` and incremented `practice_count`. The supersession chain provides a full learning history.
+1. **Acquisition.** When an agent first learns a capability, it writes a Skill grain with an initial `proficiency` (typically low). The `derived_from` field SHOULD reference the grains (Events, Tools, Reasoning) that contributed to learning.
+2. **Improvement.** Each time proficiency changes, the agent supersedes the previous Skill grain with an updated `proficiency` and incremented `practice_count`. The supersession chain provides a full learning history.
 3. **Degradation.** Implementations MAY decay proficiency over time if `last_practiced_at` exceeds a threshold. This is an index-layer concern, not a grain mutation — the store writes a new superseding grain with reduced proficiency.
 
 **Skill transfer between agents:**
 
-1. Agent A queries its store: `type=fact, relation="mg:capable_of", namespace="agent:skills", transferable=true`.
-2. Agent A shares the Skill Fact grain and all Workflow grains referenced in `strategies` with Agent B (via `get_batch` on the content addresses).
-3. Agent B ingests the grains, rewrites the Skill Fact with its own `author_did`, initial `proficiency: 0.0`, and `practice_count: 0`, and sets `derived_from` to Agent A's original Skill Fact content address. The `origin_did` field preserves Agent A's DID for provenance.
+1. Agent A queries its store: `type=skill, namespace="agent:skills", transferable=true`.
+2. Agent A shares the Skill grain and all Workflow grains referenced in `strategies` with Agent B (via `get_batch` on the content addresses).
+3. Agent B ingests the grains, rewrites the Skill grain with its own `holder_did` and `author_did`, initial `proficiency: 0.0`, and `practice_count: 0`, and sets `derived_from` to Agent A's original Skill grain content address. The `origin_did` field preserves Agent A's DID for provenance.
 4. Agent B improves proficiency through practice, superseding the skill grain as described above.
 
 **Skill discovery:**
 
-Agents discover available skills by querying: `type=fact, relation="mg:capable_of", namespace="agent:skills", system_valid_to=null, sort=proficiency DESC`.
+Agents discover available skills by querying: `type=skill, namespace="agent:skills", system_valid_to=null, sort=proficiency DESC`.
 
-To find agents capable of a specific skill: `type=fact, relation="mg:capable_of", object.name="code_review", system_valid_to=null`.
+To find agents that hold a specific skill: `type=skill, name="code_review", system_valid_to=null`.
 
-> **Note — promotion path:** If the convention approach proves insufficient — for instance, if skill queries become performance-critical across large multi-agent deployments, or if multiple domain profiles independently require skill-specific fields at the type level — a dedicated Skill grain type (`0x0B`) with its own required fields and type byte MAY be introduced in a future OMS version, following the precedent set by Consent (§8.10).
+> **Note — promotion realized:** Earlier OMS revisions modeled skills as a `Fact + mg:capable_of` convention and reserved a dedicated Skill grain type (`0x0B`) as a future promotion path, conditioned on skill queries becoming performance-critical across multi-agent deployments. OMS 1.4 realizes that promotion: Skill is now a first-class grain type (§8.11) with its own required fields and type byte, following the precedent set by Consent (§8.10).
 
 ### 28.9 CAL and SML — Companion Query and Markup Languages
 
@@ -3263,10 +3325,10 @@ version-byte  = %x01
 header-fields = flags-byte type-byte ns-hash-bytes created-at-bytes
                 ; version-byte + header-fields = 9-byte "fixed header" in §3.1
 flags-byte    = %x00-FF
-type-byte     = %x01-0A / %xF0-FF
+type-byte     = %x01-0B / %xF0-FF
                 ; Fact=0x01, Event=0x02, State=0x03, Workflow=0x04, Tool=0x05,
                 ; Observation=0x06, Goal=0x07, Reasoning=0x08, Consensus=0x09,
-                ; Consent=0x0A, 0x0B-0xEF reserved, 0xF0-0xFF domain profile types
+                ; Consent=0x0A, Skill=0x0B, 0x0C-0xEF reserved, 0xF0-0xFF domain profile types
 ns-hash-bytes = 2OCTET  ; uint16 big-endian, first two bytes of SHA-256(namespace)
 created-at-bytes = 4OCTET  ; uint32 big-endian
 
@@ -3463,6 +3525,31 @@ footer        = 32OCTET  ; SHA-256 checksum
 }
 ```
 
+**Skill-Specific Fields:**
+
+```json
+{
+  "skname": "name",
+  "instr": "instructions",
+  "wtu": "when_to_use",
+  "sver": "version",
+  "atls": "allowed_tools",
+  "res": "resources",
+  "deps": "dependencies",
+  "imod": "input_modalities",
+  "omod": "output_modalities",
+  "dom": "domain",
+  "hdid": "holder_did",
+  "prof": "proficiency",
+  "prcnt": "practice_count",
+  "lpa": "last_practiced_at",
+  "strat": "strategies",
+  "xfer": "transferable"
+}
+```
+
+> **Note:** `description` (`desc`) is shared with the Goal-specific table above; Skill grains reuse the same short key. Holder identity uses the Skill-specific `holder_did` (`hdid`), distinct from the common `author_did` (`adid`) which records the grain's writer. Bundled file payloads use the common `content_refs` (`cr`) field.
+
 **Content Reference Nested Compaction:**
 
 ```json
@@ -3596,6 +3683,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the full version history.
 - **Reasoning:** Grain type 0x08 — an inference chain, chain-of-thought, or decision rationale
 - **Consensus:** Grain type 0x09 — an agreement reached among multiple agents or sources
 - **Consent:** Grain type 0x0A — a data subject's GDPR/CCPA/LGPD/PIPL consent or withdrawal record
+- **Skill:** Grain type 0x0B — a packaged, reusable agent capability: a definition (instructions, when-to-use, tools, resources, dependencies) with optional learned-competence fields (proficiency, practice count, strategies)
 - **processing_basis:** Legal basis for processing personal data under GDPR Art. 6 (consent, contract, legal_obligation, vital_interests, public_task, legitimate_interests)
 - **consent_cascade:** Invalidation mode that propagates erasure/restriction to all grains linked via `processing_basis` when a Consent grain is invalidated
 - **verification_status:** Lifecycle verification state of a grain's content: `"unverified"` (default — not yet reviewed), `"verified"` (confirmed correct by an authority), `"contested"` (contradicted or disputed), `"retracted"` (withdrawn from use)
@@ -3656,7 +3744,7 @@ content_address = sha256(blob).hex()
 
 ---
 
-**Document Status:** This is a v1.4 revision of the .mg format specification. This revision renames grain type `0x01` from `belief` to `fact` and grain type `0x05` from `action` to `tool` (byte values unchanged — existing content addresses remain valid), redesigns the Workflow grain as a directed graph, and adds the `embedding_text` common field for retrieval. Submitted as a standards track document for consideration as an IETF RFC and W3C standard. Community feedback is encouraged through issue tracking and discussion forums.
+**Document Status:** This is the v1.4 revision of the .mg format specification. This revision renames grain type `0x01` from `belief` to `fact` and grain type `0x05` from `action` to `tool` (byte values unchanged — existing content addresses remain valid), redesigns the Workflow grain as a directed graph, adds the `embedding_text` common field for retrieval, and adds the dedicated **Skill** grain type (`0x0B`, §8.11) — promoting the former §28.8 Skill Convention to a first-class type — for packaged, reusable agent capabilities. Submitted as a standards track document for consideration as an IETF RFC and W3C standard. Community feedback is encouraged through issue tracking and discussion forums.
 
 **Last Updated:** 2026-06-12
 **License:** This document is offered under the Open Web Foundation Final Specification Agreement (OWFa 1.0)

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -144,7 +144,7 @@ OMS defines the wire format and grain semantics. Two companion specifications ar
 
 CAL is a non-destructive, deterministic, LLM-native language for assembling agent context from OMS memory stores. It answers the question: *"what should be in the agent's context window right now?"* Key properties:
 
-- Operates on all 10 OMS grain types (Belief, Event, State, Workflow, Action, Observation, Goal, Reasoning, Consensus, Consent)
+- Operates on all 10 OMS grain types (Fact, Event, State, Workflow, Action, Observation, Goal, Reasoning, Consensus, Consent)
 - Extends the OMS Store Protocol (§28.4) with a formal, structured query syntax
 - `ASSEMBLE` statements compose context from multiple grain sources within a token budget
 - Append-only: CAL writes create new grains via `put`; the language cannot delete or modify existing grains — this is enforced at the grammar level
@@ -152,7 +152,7 @@ CAL is a non-destructive, deterministic, LLM-native language for assembling agen
 
 **SML — Semantic Markup Language** ([SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md](./SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md))
 
-SML is a flat, tag-based markup format optimized for LLM context consumption. It is not XML. Tag names are OMS grain types (`<belief>`, `<goal>`, `<event>`, …); attributes carry lightweight decision metadata; text content is natural language. SML is the default output format for CAL `ASSEMBLE` statements and is designed to be consumed directly by an LLM without an XML processor.
+SML is a flat, tag-based markup format optimized for LLM context consumption. It is not XML. Tag names are OMS grain types (`<fact>`, `<goal>`, `<event>`, …); attributes carry lightweight decision metadata; text content is natural language. SML is the default output format for CAL `ASSEMBLE` statements and is designed to be consumed directly by an LLM without an XML processor.
 
 ---
 
@@ -197,11 +197,11 @@ Hexadecimal values are lowercase. Byte sequences are represented in hex with spa
 
 | Value | Type | Description |
 |-------|------|-------------|
-| 0x01 | **Belief** | Structured belief — (subject, relation, object) triple with confidence and source |
+| 0x01 | **Fact** | Structured fact — (subject, relation, object) triple with confidence and source |
 | 0x02 | **Event** | Timestamped occurrence — message, interaction, or behavioral event |
 | 0x03 | **State** | Agent state snapshot — portable save point |
 | 0x04 | **Workflow** | Directed graph of procedural steps — plans, pipelines, processes |
-| 0x05 | **Action** | Tool invocation or code execution |
+| 0x05 | **Tool** | Tool invocation or code execution |
 | 0x06 | **Observation** | Raw sensory or cognitive input |
 | 0x07 | **Goal** | Objective with lifecycle semantics |
 | 0x08 | **Reasoning** | Inference chain and thought audit trail |
@@ -480,7 +480,7 @@ To minimize blob size, human-readable field names are mapped to short keys befor
 | Full Name | Short Key | Type | Notes |
 |-----------|-----------|------|-------|
 | `content` | `content` | string | Raw text of the event. MAY be omitted if `content_blocks` is present. |
-| `consolidated` | `consolidated` | bool | Whether this event has been distilled into Belief grains |
+| `consolidated` | `consolidated` | bool | Whether this event has been distilled into Fact grains |
 | `content_blocks` | `cblocks` | array[map] | Typed content blocks for structured LLM messages. When present, takes precedence over flat `content` string. Each entry: `{type: "text"/"image"/"tool_use"/"tool_result"/"thinking", ...}`. See note below. |
 | `model_id` | `mdl` | string | LLM model identifier that produced the response (e.g., `"claude-opus-4-6"`, `"gpt-4o"`). Absent for human-authored events. |
 | `stop_reason` | `stopr` | string | Why LLM generation stopped: `"end_turn"`, `"max_tokens"`, `"stop_sequence"`, `"tool_use"`. Open enum. |
@@ -533,7 +533,7 @@ To minimize blob size, human-readable field names are mapped to short keys befor
 | `stdout` | `out` | string | Standard output from code execution |
 | `stderr` | `err2` | string | Standard error from code execution |
 | `exit_code` | `xc` | int | Process exit code from code execution |
-| `interpreter_id` | `iid` | string | Links Action grains sharing a stateful interpreter session |
+| `interpreter_id` | `iid` | string | Links Tool grains sharing a stateful interpreter session |
 | `error` | `err` | string | Error message (use with `is_error: true`) |
 | `error_type` | `etype` | string | Structured error classification: `"timeout"`, `"rate_limit"`, `"auth_failure"`, `"invalid_input"`, `"server_error"`, `"not_found"`, `"quota_exceeded"`. Open enum. Enables retry policy decisions without parsing free-text `error`. |
 | `duration_ms` | `dur` | int | Execution time in milliseconds |
@@ -624,12 +624,12 @@ To minimize blob size, human-readable field names are mapped to short keys befor
 
 ### 6.11 Delegation-Specific Fields
 
-When a Goal or Belief grain uses the `mg:delegates_to` relation, the following fields specify the scope and constraints of the delegation. Without these fields, a delegation is unbounded — the delegatee receives no machine-readable limits. Implementations SHOULD populate delegation scope fields for any inter-agent authority grant.
+When a Goal or Fact grain uses the `mg:delegates_to` relation, the following fields specify the scope and constraints of the delegation. Without these fields, a delegation is unbounded — the delegatee receives no machine-readable limits. Implementations SHOULD populate delegation scope fields for any inter-agent authority grant.
 
 | Full Name | Short Key | Type | Notes |
 |-----------|-----------|------|-------|
 | `authorized_namespaces` | `ans` | array[string] | Namespaces the delegatee may read and write. `["*"]` = all namespaces (dangerous — SHOULD be avoided). |
-| `authorized_types` | `atypes` | array[uint8] | Grain type bytes the delegatee may create. E.g., `[0x01, 0x02, 0x05]` for Belief, Event, Action. |
+| `authorized_types` | `atypes` | array[uint8] | Grain type bytes the delegatee may create. E.g., `[0x01, 0x02, 0x05]` for Fact, Event, Tool. |
 | `authorized_tools` | `atools` | array[string] | Tool names the delegatee may invoke. Empty array = no tool restriction. |
 | `delegation_depth` | `ddepth` | int | Maximum re-delegation depth. 0 = delegatee MUST NOT re-delegate. Absent = unlimited (NOT RECOMMENDED). |
 | `delegation_expiry` | `dexp` | int64 | Epoch ms when delegation expires. After expiry, the delegatee's writes SHOULD be rejected by stores that enforce delegation scope. |
@@ -736,9 +736,9 @@ The `mg:` namespace is reserved for standard semantic relations. Applications de
 | Relation | Typical grain type | Meaning |
 |---|---|---|
 | `mg:perceives` | Observation | Raw sensory or cognitive input |
-| `mg:knows` | Belief | Derived belief or learned fact |
+| `mg:knows` | Fact | Derived fact or learned fact |
 | `mg:said` | Event | Message or utterance |
-| `mg:did` | Action | Tool or action invocation |
+| `mg:did` | Tool | Tool or action invocation |
 | `mg:infers` | Reasoning | Derived conclusion from prior grains |
 | `mg:agrees_with` | Consensus | Multi-agent threshold agreement |
 | `mg:state_at` | State | Agent state snapshot |
@@ -746,24 +746,24 @@ The `mg:` namespace is reserved for standard semantic relations. Applications de
 | `mg:intends` | Goal | Agent objective |
 | `mg:permits` | Consent | User grants agent right to retain or act |
 | `mg:revokes` | Consent | User revokes prior consent |
-| `mg:prohibits` | Belief/Goal | Hard prohibition |
-| `mg:requires` | Belief/Goal | Hard requirement |
-| `mg:prefers` | Belief | Soft preference |
-| `mg:avoids` | Belief | Soft avoidance preference |
+| `mg:prohibits` | Fact/Goal | Hard prohibition |
+| `mg:requires` | Fact/Goal | Hard requirement |
+| `mg:prefers` | Fact | Soft preference |
+| `mg:avoids` | Fact | Soft avoidance preference |
 | `mg:delegates_to` | Goal | Scoped authority grant (§6.11 delegation scope) |
-| `mg:owned_by` | Belief | Legal entity ownership (§12.5) |
-| `mg:has_capability` | Belief | Agent capability advertisement (§28.5 Agent Card) |
+| `mg:owned_by` | Fact | Legal entity ownership (§12.5) |
+| `mg:has_capability` | Fact | Agent capability advertisement (§28.5 Agent Card) |
 | `mg:handed_off_to` | Event | Session handoff event record (§28.7) |
 | `mg:depends_on` | Goal | Task dependency (distinct from `parent_goals` hierarchy) |
 | `mg:assigned_to` | Goal | Task assigned to agent for execution |
-| `mg:capable_of` | Belief | Learned skill with proficiency and strategies (§28.8 Skill Convention) |
+| `mg:capable_of` | Fact | Learned skill with proficiency and strategies (§28.8 Skill Convention) |
 
-### 8.1 Belief (type = 0x01)
+### 8.1 Fact (type = 0x01)
 
-A structured belief about the world — a (subject, relation, object) triple with confidence and source. The canonical unit of declarative knowledge.
+A structured fact about the world — a (subject, relation, object) triple with confidence and source. The canonical unit of declarative knowledge.
 
 **Required fields:**
-- `type` = "belief" (payload string; header byte = `0x01`)
+- `type` = "fact" (payload string; header byte = `0x01`)
 - `subject` (non-empty string)
 - `relation` (non-empty string)
 - `object` (string or map)
@@ -844,7 +844,7 @@ Directed graph of procedural steps — plans, pipelines, and multi-path processe
 | Named | No binding, but an Action definition grain exists with matching `tool_name` | Resolve by convention (implementation-defined lookup) |
 | Abstract | No binding, no matching tool | Node label is a human-readable instruction; executor (LLM or agent) interprets it |
 
-**Execution record relation:** When an agent executes a workflow node, it creates an Action grain (phase: complete or call/result) with a relation of type `mg:step_action:<node_id>` targeting the Workflow grain hash. This links execution records to the plan without modifying the immutable Workflow grain.
+**Execution record relation:** When an agent executes a workflow node, it creates an Tool grain (phase: complete or call/result) with a relation of type `mg:step_action:<node_id>` targeting the Workflow grain hash. This links execution records to the plan without modifying the immutable Workflow grain.
 
 **Example — linear pipeline:**
 
@@ -942,7 +942,7 @@ An explicit objective with lifecycle semantics. Goals transition through states 
 
 **Optional fields:** `criteria`, `criteria_structured`, `priority`, `parent_goals`, `depends_on` (array[string] — content addresses of prerequisite Goal grains that must complete before this one starts; distinct from `parent_goals` which implies decomposition, not dependency ordering), `assigned_agent` (string — DID of the agent assigned to execute this task), `expected_output` (string — description of expected output format), `output_grain` (string — content address of the grain containing the task's completed output), `deadline` (int64 — epoch ms hard deadline for task completion), `state_reason`, `satisfaction_evidence`, `progress`, `delegate_to`, `delegate_from`, `expiry_policy`, `recurrence`, `evidence_required`, `rollback_on_failure`, `allowed_transitions`, all common fields.
 
-Constraints, policies, and delegations are expressed as Goal or Belief grains with `mg:prohibits`, `mg:prefers`, `mg:avoids`, or `mg:delegates_to` relations, combined with `invalidation_policy` (§23) for enforcement.
+Constraints, policies, and delegations are expressed as Goal or Fact grains with `mg:prohibits`, `mg:prefers`, `mg:avoids`, or `mg:delegates_to` relations, combined with `invalidation_policy` (§23) for enforcement.
 
 > **Note — plan-and-execute agents:** The `depends_on` field enables DAG-structured task dependency graphs for hierarchical task decomposition. Agents using plan-and-execute patterns (e.g., LangGraph StateGraph, CrewAI task dependencies) SHOULD express task ordering via `depends_on` and task hierarchy via `parent_goals`. A Goal grain with `depends_on` references MUST NOT transition to `goal_state: "active"` until all referenced Goal grains have `goal_state: "satisfied"`. The `assigned_agent` field enables multi-agent task routing: the orchestrator creates Goal grains with `assigned_agent` pointing to worker agent DIDs.
 
@@ -987,7 +987,7 @@ A multi-agent agreement record — N observers voted on a shared claim, threshol
 
 ### 8.10 Consent (type = 0x0A)
 
-A DID-scoped, purpose-bounded permission grant or withdrawal. Four of six industry review domains independently required a dedicated Consent type at the type-byte level — HIPAA patient consent, legal privilege and DPA, regulatory consent, and GDPR/CCPA at scale. The `Belief + mg:permits` pattern is semantically correct but impractical when consent queries are compliance-critical and frequent.
+A DID-scoped, purpose-bounded permission grant or withdrawal. Four of six industry review domains independently required a dedicated Consent type at the type-byte level — HIPAA patient consent, legal privilege and DPA, regulatory consent, and GDPR/CCPA at scale. The `Fact + mg:permits` pattern is semantically correct but impractical when consent queries are compliance-critical and frequent.
 
 **Required fields:**
 - `type` = "consent"
@@ -1386,11 +1386,11 @@ For non-person memory (seasonal, device, system), `user_id` is simply omitted. `
 
 ### 12.5 Agent Ownership and Legal Entity
 
-An agent may belong to a legal entity — a natural person or a juridical person (company, partnership, NGO, government body). OMS expresses this relationship as a protected Belief grain written at agent provisioning time by the operator, not by the agent itself.
+An agent may belong to a legal entity — a natural person or a juridical person (company, partnership, NGO, government body). OMS expresses this relationship as a protected Fact grain written at agent provisioning time by the operator, not by the agent itself.
 
 #### 12.5.1 The `owner` Field
 
-Any grain type MAY carry an `owner` field (compacted: `own`) containing a **LegalEntity** map. In practice, `owner` is used in the ownership Belief grain described in §12.5.3. It MUST NOT be used as an access control gate — `invalidation_policy` (§23) governs supersession authorization.
+Any grain type MAY carry an `owner` field (compacted: `own`) containing a **LegalEntity** map. In practice, `owner` is used in the ownership Fact grain described in §12.5.3. It MUST NOT be used as an access control gate — `invalidation_policy` (§23) governs supersession authorization.
 
 **LegalEntity sub-schema:**
 
@@ -1441,9 +1441,9 @@ This is an open enum. Implementations MAY define additional values for jurisdict
 
 Prefixes not listed here MUST be preserved as-is. New prefixes do not require a spec update.
 
-#### 12.5.3 Ownership Belief Grain Convention
+#### 12.5.3 Ownership Fact Grain Convention
 
-Agent ownership is expressed as a Belief grain with `relation: "mg:owned_by"` in the `"agent:identity"` namespace. The `object` field carries the owner's legal name as a string (for semantic triple completeness). The structured `owner` field carries the full LegalEntity map.
+Agent ownership is expressed as a Fact grain with `relation: "mg:owned_by"` in the `"agent:identity"` namespace. The `object` field carries the owner's legal name as a string (for semantic triple completeness). The structured `owner` field carries the full LegalEntity map.
 
 This grain MUST be written by the operator at agent provisioning time. It MUST carry an `invalidation_policy` (§23) restricting supersession to the owner's authorized DID. It SHOULD be COSE-signed (§9) by the owner's DID.
 
@@ -1451,7 +1451,7 @@ This grain MUST be written by the operator at agent provisioning time. It MUST c
 
 ```json
 {
-  "type": "belief",
+  "type": "fact",
   "subject": "did:web:example.com:agents:my-agent",
   "relation": "mg:owned_by",
   "object": "Example Corp Pvt. Ltd.",
@@ -1481,7 +1481,7 @@ This grain MUST be written by the operator at agent provisioning time. It MUST c
 
 ```json
 {
-  "type": "belief",
+  "type": "fact",
   "subject": "did:key:z6MkAgentDID...",
   "relation": "mg:owned_by",
   "object": "Jane Doe",
@@ -1525,7 +1525,7 @@ This grain MUST be written by the operator at agent provisioning time. It MUST c
 1. The ownership grain MUST NOT be authored by the agent's own DID. Only the operator's DID is authorized to write it (key separation, §23.8).
 2. The `subject` MUST be the agent's DID.
 3. When multiple grains with `relation: "owned_by"` exist for the same `subject` in the `"agent:identity"` namespace, the grain with `invalidation_policy.mode ≠ "open"` is authoritative. Stores SHOULD surface it as the canonical ownership record.
-4. An agent observing a user assertion that contradicts the locked ownership grain MAY record that claim as an Observation grain. It MUST NOT write a superseding ownership Belief without the authorized signature.
+4. An agent observing a user assertion that contradicts the locked ownership grain MAY record that claim as an Observation grain. It MUST NOT write a superseding ownership Fact without the authorized signature.
 
 #### 12.5.4 Protection Layers
 
@@ -1796,7 +1796,7 @@ All Level 2 requirements, plus:
 - Hash-chained audit trail
 - Crash recovery and reconciliation
 - Policy engine with compliance presets
-- SHOULD partition Observation grain storage by observer domain, inferred from `observer_type`. Physical observer types (see Section 24) SHOULD flow to time-series storage with raw-data retention policies. Cognitive observer types SHOULD flow to vector + relational storage with the same retrieval semantics as Belief grains. Implementations MUST NOT hard-code the domain partition list — treat `observer_type` as an open string and drive routing from configuration or namespace.
+- SHOULD partition Observation grain storage by observer domain, inferred from `observer_type`. Physical observer types (see Section 24) SHOULD flow to time-series storage with raw-data retention policies. Cognitive observer types SHOULD flow to vector + relational storage with the same retrieval semantics as Fact grains. Implementations MUST NOT hard-code the domain partition list — treat `observer_type` as an open string and drive routing from configuration or namespace.
 
 ---
 
@@ -1977,7 +1977,7 @@ cb 3f ec cc cc cc cc cc cd a2 63 61 cf 00 00 01 9b c1 19 01 00 a2 6e 73 a6
 69 74 a1 74 a4 66 61 63 74
 ```
 
-> Header breakdown: `01`=version, `00`=flags (public, MessagePack, unsigned), `01`=Belief type, `a4 d2`=SHA-256("shared")[0:2] as uint16 big-endian, `69 68 ba a0`=created_at_sec (1768471200 = 2026-01-15T10:00:00Z, big-endian).
+> Header breakdown: `01`=version, `00`=flags (public, MessagePack, unsigned), `01`=Fact type, `a4 d2`=SHA-256("shared")[0:2] as uint16 big-endian, `69 68 ba a0`=created_at_sec (1768471200 = 2026-01-15T10:00:00Z, big-endian).
 >
 > Payload breakdown: `89`=fixmap(9), `a4 61 64 69 64`=key "adid" (fixstr 4), `d9 38`=str8 length 56, followed by 56 UTF-8 bytes of the DID; key `c` value: `cb 3f ec cc cc cc cc cc cd` (float64 marker + 8 bytes = `3feccccccccccccd` = 0.9); then remaining keys "ca"/"ns"/"o"/"r"/"s"/"st"/"t" in lexicographic order with their values.
 
@@ -2000,12 +2000,12 @@ cb 3f ec cc cc cc cc cc cd a2 63 61 cf 00 00 01 9b c1 19 01 00 a2 6e 73 a6
 [computed by reference implementation]
 ```
 
-### 21.3 Vector 3: Bi-Temporal Belief
+### 21.3 Vector 3: Bi-Temporal Fact
 
 **Input:**
 ```json
 {
-  "type": "belief",
+  "type": "fact",
   "subject": "Alice",
   "relation": "works_at",
   "object": "Acme Corp",
@@ -2024,12 +2024,12 @@ cb 3f ec cc cc cc cc cc cd a2 63 61 cf 00 00 01 9b c1 19 01 00 a2 6e 73 a6
 [computed by reference implementation]
 ```
 
-### 21.4 Vector 4: Belief with Cross-Links
+### 21.4 Vector 4: Fact with Cross-Links
 
 **Input:**
 ```json
 {
-  "type": "belief",
+  "type": "fact",
   "subject": "Bob",
   "relation": "manages",
   "object": "Project Alpha",
@@ -2179,7 +2179,7 @@ To verify conformance:
 
 ### 22.7 Streaming and Partial Results
 
-OMS grains are atomic, immutable knowledge units. Streaming outputs (e.g., token-by-token LLM responses, incremental tool results, partial server-sent events) are transport-layer concerns outside OMS scope. Implementations SHOULD buffer streaming content in their transport layer and emit a single immutable Event or Action grain upon stream completion. For long-running tool executions requiring progress visibility, implementations MAY emit periodic State grains (type 0x03) as progress checkpoints, linked via `derived_from` to the originating Action grain. Each checkpoint is a complete, self-contained grain — not a diff.
+OMS grains are atomic, immutable knowledge units. Streaming outputs (e.g., token-by-token LLM responses, incremental tool results, partial server-sent events) are transport-layer concerns outside OMS scope. Implementations SHOULD buffer streaming content in their transport layer and emit a single immutable Event or Tool grain upon stream completion. For long-running tool executions requiring progress visibility, implementations MAY emit periodic State grains (type 0x03) as progress checkpoints, linked via `derived_from` to the originating Tool grain. Each checkpoint is a complete, self-contained grain — not a diff.
 
 ### 22.8 Recall Priority and Agent Memory Tiers
 
@@ -2201,10 +2201,10 @@ For cross-framework agent state portability, implementations SHOULD use the foll
 |---|---|---|
 | `messages_tail` | string | Content address of the most recent Event grain in the conversation |
 | `memory_blocks` | map | Named memory blocks: `{block_name: block_value_string}`. Letta-compatible. |
-| `system_prompt` | string | System prompt text, or content address of a Belief grain containing it |
+| `system_prompt` | string | System prompt text, or content address of a Fact grain containing it |
 | `active_tools` | array[string] | Tool names available in this agent state |
 | `model` | string | LLM model identifier (e.g., `"claude-opus-4-6"`) |
-| `pending_tool_calls` | array[string] | Content addresses of Action grains in `"call"` phase awaiting results |
+| `pending_tool_calls` | array[string] | Content addresses of Tool grains in `"call"` phase awaiting results |
 | `agent_config` | map | Framework-specific agent configuration (opaque to the spec) |
 
 This schema is RECOMMENDED, not required. Implementations MAY include additional keys. The `memory_blocks` key is aligned with Letta's `core_memory` structure. The `messages_tail` key enables reconstructing the conversation by following `parent_message_id` chains backward from the tail.
@@ -2445,7 +2445,7 @@ The `observation_scope` field is a **closed enum**. It describes the temporal br
 
 ## 27. Grain Type Field Specifications
 
-This section provides detailed field specifications for each standard grain type. For Action grain phase fields, see §27.1. For Observer types, see §24. For Observation modes/scopes, see §25/§26.
+This section provides detailed field specifications for each standard grain type. For Tool grain phase fields, see §27.1. For Observer types, see §24. For Observation modes/scopes, see §25/§26.
 
 ### 27.1 Action Grain (type = 0x05) — Phase and Mode Details
 
@@ -2578,7 +2578,7 @@ The `action_phase` field acts as a discriminator for async vs. synchronous tool 
 | `"goal_decomposition"` | Agent decomposed a parent goal |
 | `"goal_state_transition"` | Updates state of a prior Goal grain |
 | `"goal_revision"` | Human modified a previously set goal |
-| `"goal_inference"` | Agent inferred from Event or Belief patterns |
+| `"goal_inference"` | Agent inferred from Event or Fact patterns |
 | `"goal_delegation"` | Delegated from another agent |
 
 ### 27.3 `source_type` Registry
@@ -2846,12 +2846,12 @@ Stores SHOULD implement `supersede` as a distinct operation rather than exposing
 
 ### 28.5 Agent Capability Convention
 
-Agents that participate in multi-agent systems SHOULD advertise their capabilities by writing a Belief grain with the `mg:has_capability` relation to the `"agent:identity"` namespace. This grain serves as the OMS equivalent of an A2A Agent Card or MCP server capability declaration.
+Agents that participate in multi-agent systems SHOULD advertise their capabilities by writing a Fact grain with the `mg:has_capability` relation to the `"agent:identity"` namespace. This grain serves as the OMS equivalent of an A2A Agent Card or MCP server capability declaration.
 
 **Convention:**
 ```json
 {
-  "type": "belief",
+  "type": "fact",
   "subject": "did:web:example.com:agents:summarizer",
   "relation": "mg:has_capability",
   "object": {
@@ -2887,7 +2887,7 @@ The `object` map is an open schema. Standard keys:
 | `max_context_tokens` | int | Maximum context window in tokens |
 | `model` | string | Underlying LLM model identifier |
 
-Agents can discover other agents by querying Belief grains with `relation: "mg:has_capability"` in the `"agent:identity"` namespace.
+Agents can discover other agents by querying Fact grains with `relation: "mg:has_capability"` in the `"agent:identity"` namespace.
 
 ### 28.6 Conversation Threading Convention
 
@@ -2897,7 +2897,7 @@ Conversations are reconstructed from Event grain sequences using `session_id` an
 2. Event grains SHOULD populate `parent_message_id` (§6.2) to form a linked list from newest to oldest.
 3. Branch points are expressed by two Event grains sharing the same `parent_message_id` but having different content addresses (tree-of-thought, beam search, alternative paths).
 4. A State grain (type 0x03) with `relation: "mg:state_at"` and a `context` map containing `{messages_tail, message_count, participants}` represents a conversation snapshot.
-5. Conversation summaries are Belief grains with `consolidation_level >= 1`, `derived_from` pointing to the summarized Event grains, and `source_type: "consolidated"`.
+5. Conversation summaries are Fact grains with `consolidation_level >= 1`, `derived_from` pointing to the summarized Event grains, and `source_type: "consolidated"`.
 
 **Retrieving a conversation:**
 1. Query: `type=event, session_id=X, system_valid_to=null, sort=timestamp_ms ASC`
@@ -2908,26 +2908,26 @@ Conversations are reconstructed from Event grain sequences using `session_id` an
 When Agent A transfers control of a conversation to Agent B, the handoff is recorded using a Goal grain with `mg:delegates_to` relation and delegation scope fields (§6.11):
 
 1. Agent A writes a Goal grain with `relation: "mg:delegates_to"`, `subject` = Agent A's DID, `object` = Agent B's DID, and delegation scope fields specifying `authorized_namespaces`, `authorized_tools`, `context_grains`, and `return_to`.
-2. The `context_grains` field contains content addresses of grains Agent B needs to continue — typically the recent Event grain chain and any relevant Belief/State grains.
+2. The `context_grains` field contains content addresses of grains Agent B needs to continue — typically the recent Event grain chain and any relevant Fact/State grains.
 3. Agent B ingests the referenced grains, validates the delegation scope, and continues with a new `run_id` but the same `session_id`.
 4. When Agent B completes its task, it writes a Goal grain with `goal_state: "satisfied"` linked via `derived_from` to the delegation grain, and control returns to the agent specified in `return_to`.
 
 ### 28.8 Skill Convention
 
-Agents that learn reusable capabilities SHOULD represent them as Belief grains with `relation: "mg:capable_of"` and a structured `object` map. A skill grain captures what an agent can do, how well it can do it, and the procedural knowledge needed to transfer the capability to another agent.
+Agents that learn reusable capabilities SHOULD represent them as Fact grains with `relation: "mg:capable_of"` and a structured `object` map. A skill grain captures what an agent can do, how well it can do it, and the procedural knowledge needed to transfer the capability to another agent.
 
 **Distinction from related constructs:**
 
 | Construct | Grain type | What it captures |
 |---|---|---|
-| Agent Capability (§28.5) | Belief (`mg:has_capability`) | Static identity card — what the agent *is built to do* |
-| Skill (§28.8) | Belief (`mg:capable_of`) | Learned capability — what the agent *has learned to do*, with proficiency and strategies |
+| Agent Capability (§28.5) | Fact (`mg:has_capability`) | Static identity card — what the agent *is built to do* |
+| Skill (§28.8) | Fact (`mg:capable_of`) | Learned capability — what the agent *has learned to do*, with proficiency and strategies |
 | Workflow (§8.4) | Workflow | Fixed action sequence — a single procedure, not an adaptive capability |
 
 **Convention:**
 ```json
 {
-  "type": "belief",
+  "type": "fact",
   "subject": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
   "relation": "mg:capable_of",
   "object": {
@@ -2970,7 +2970,7 @@ The `object` map is an open schema. Standard keys:
 | `description` | string | Human-readable summary of what the skill enables |
 | `proficiency` | float64, [0.0, 1.0] | Current mastery level. SHOULD equal the grain's top-level `confidence`. |
 | `strategies` | array[map] | Context-dependent approaches. Each entry: `{condition: string, workflow: string, description?: string}`. The `workflow` value is a content address of a Workflow grain (§8.4). |
-| `prerequisites` | array[string] | Content addresses of Skill Belief grains that must be acquired before this skill is effective |
+| `prerequisites` | array[string] | Content addresses of Skill Fact grains that must be acquired before this skill is effective |
 | `practice_count` | int | Number of successful applications (mirrors `success_count` in core fields) |
 | `last_practiced_at` | int64 | Epoch ms of most recent successful application |
 | `transferable` | bool | If `true`, another agent MAY ingest this grain and its referenced Workflow grains to acquire the skill |
@@ -2978,26 +2978,26 @@ The `object` map is an open schema. Standard keys:
 | `output_modalities` | array[string] | What the skill produces |
 | `domain` | string | Domain context: `"software"`, `"research"`, `"healthcare"`, `"finance"`. Open enum. |
 
-**Namespace:** Skill Belief grains SHOULD use the `"agent:skills"` namespace to enable efficient discovery queries.
+**Namespace:** Skill Fact grains SHOULD use the `"agent:skills"` namespace to enable efficient discovery queries.
 
 **Proficiency lifecycle:**
 
-1. **Acquisition.** When an agent first learns a capability, it writes a Skill Belief grain with an initial `proficiency` (typically low). The `derived_from` field SHOULD reference the grains (Events, Actions, Reasoning) that contributed to learning.
-2. **Improvement.** Each time proficiency changes, the agent supersedes the previous Skill Belief grain with an updated `proficiency` and incremented `practice_count`. The supersession chain provides a full learning history.
+1. **Acquisition.** When an agent first learns a capability, it writes a Skill Fact grain with an initial `proficiency` (typically low). The `derived_from` field SHOULD reference the grains (Events, Actions, Reasoning) that contributed to learning.
+2. **Improvement.** Each time proficiency changes, the agent supersedes the previous Skill Fact grain with an updated `proficiency` and incremented `practice_count`. The supersession chain provides a full learning history.
 3. **Degradation.** Implementations MAY decay proficiency over time if `last_practiced_at` exceeds a threshold. This is an index-layer concern, not a grain mutation — the store writes a new superseding grain with reduced proficiency.
 
 **Skill transfer between agents:**
 
-1. Agent A queries its store: `type=belief, relation="mg:capable_of", namespace="agent:skills", transferable=true`.
-2. Agent A shares the Skill Belief grain and all Workflow grains referenced in `strategies` with Agent B (via `get_batch` on the content addresses).
-3. Agent B ingests the grains, rewrites the Skill Belief with its own `author_did`, initial `proficiency: 0.0`, and `practice_count: 0`, and sets `derived_from` to Agent A's original Skill Belief content address. The `origin_did` field preserves Agent A's DID for provenance.
+1. Agent A queries its store: `type=fact, relation="mg:capable_of", namespace="agent:skills", transferable=true`.
+2. Agent A shares the Skill Fact grain and all Workflow grains referenced in `strategies` with Agent B (via `get_batch` on the content addresses).
+3. Agent B ingests the grains, rewrites the Skill Fact with its own `author_did`, initial `proficiency: 0.0`, and `practice_count: 0`, and sets `derived_from` to Agent A's original Skill Fact content address. The `origin_did` field preserves Agent A's DID for provenance.
 4. Agent B improves proficiency through practice, superseding the skill grain as described above.
 
 **Skill discovery:**
 
-Agents discover available skills by querying: `type=belief, relation="mg:capable_of", namespace="agent:skills", system_valid_to=null, sort=proficiency DESC`.
+Agents discover available skills by querying: `type=fact, relation="mg:capable_of", namespace="agent:skills", system_valid_to=null, sort=proficiency DESC`.
 
-To find agents capable of a specific skill: `type=belief, relation="mg:capable_of", object.name="code_review", system_valid_to=null`.
+To find agents capable of a specific skill: `type=fact, relation="mg:capable_of", object.name="code_review", system_valid_to=null`.
 
 > **Note — promotion path:** If the convention approach proves insufficient — for instance, if skill queries become performance-critical across large multi-agent deployments, or if multiple domain profiles independently require skill-specific fields at the type level — a dedicated Skill grain type (`0x0B`) with its own required fields and type byte MAY be introduced in a future OMS version, following the precedent set by Consent (§8.10).
 
@@ -3020,7 +3020,7 @@ CAL extends the store operations defined in §28.4 with a structured query langu
 
 **SML output format:**
 
-CAL `ASSEMBLE` statements produce **SML (Semantic Markup Language)** output by default. SML is a flat, tag-based markup format optimized for LLM consumption: tag names are OMS grain types (`<belief>`, `<goal>`, `<event>`, …), attributes carry lightweight metadata, and text content is natural language. See the [SML specification](./SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md) for the full format definition, structural rules, and progressive disclosure model. Implementations that expose a query layer SHOULD support CAL and produce SML output for agent context assembly.
+CAL `ASSEMBLE` statements produce **SML (Semantic Markup Language)** output by default. SML is a flat, tag-based markup format optimized for LLM consumption: tag names are OMS grain types (`<fact>`, `<goal>`, `<event>`, …), attributes carry lightweight metadata, and text content is natural language. See the [SML specification](./SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md) for the full format definition, structural rules, and progressive disclosure model. Implementations that expose a query layer SHOULD support CAL and produce SML output for agent context assembly.
 
 ---
 
@@ -3264,7 +3264,7 @@ header-fields = flags-byte type-byte ns-hash-bytes created-at-bytes
                 ; version-byte + header-fields = 9-byte "fixed header" in §3.1
 flags-byte    = %x00-FF
 type-byte     = %x01-0A / %xF0-FF
-                ; Belief=0x01, Event=0x02, State=0x03, Workflow=0x04, Action=0x05,
+                ; Fact=0x01, Event=0x02, State=0x03, Workflow=0x04, Action=0x05,
                 ; Observation=0x06, Goal=0x07, Reasoning=0x08, Consensus=0x09,
                 ; Consent=0x0A, 0x0B-0xEF reserved, 0xF0-0xFF domain profile types
 ns-hash-bytes = 2OCTET  ; uint16 big-endian, first two bytes of SHA-256(namespace)
@@ -3586,11 +3586,11 @@ See [CHANGELOG.md](CHANGELOG.md) for the full version history.
 - **Provenance:** Derivation trail showing how grain was created
 - **Cross-link:** Semantic relationship between grains
 - **Bi-temporal:** Tracking both event-time and system-time dimensions
-- **Belief:** Grain type 0x01 — a held claim, factual statement, or declarative knowledge about the world
+- **Fact:** Grain type 0x01 — a held claim, factual statement, or declarative knowledge about the world
 - **Event:** Grain type 0x02 — a discrete occurrence with start/end time
 - **State:** Grain type 0x03 — a persisting condition or status at a point in time
 - **Workflow:** Grain type 0x04 — a directed graph of procedural steps, supporting sequential, conditional, parallel, and cyclic execution paths
-- **Action:** Grain type 0x05 — a completed tool invocation, API call, or agent action
+- **Tool:** Grain type 0x05 — a completed tool invocation, API call, or agent action
 - **Observation:** Grain type 0x06 — a raw sensor or environmental reading without interpretation
 - **Goal:** Grain type 0x07 — a desired future state or objective
 - **Reasoning:** Grain type 0x08 — an inference chain, chain-of-thought, or decision rationale
@@ -3608,9 +3608,9 @@ See [CHANGELOG.md](CHANGELOG.md) for the full version history.
 ## Appendix G: Complete Example Grain
 
 ```python
-# Create a belief grain
+# Create a fact grain
 grain = {
-    "type": "belief",
+    "type": "fact",
     "subject": "machine-learning",
     "relation": "is_subset_of",
     "object": "artificial-intelligence",
@@ -3644,7 +3644,7 @@ grain = {
 # 4. Sort keys lexicographically
 # 5. Encode as canonical MessagePack
 # 6. Prepend 9-byte fixed header: version(1) + flags(1) + type(1) + ns_hash(2) + created_at(4)
-#    type byte = 0x01 (Belief)
+#    type byte = 0x01 (Fact)
 # 7. Compute SHA-256 hash
 
 blob = serialize(grain)
@@ -3656,7 +3656,7 @@ content_address = sha256(blob).hex()
 
 ---
 
-**Document Status:** This is a v1.3 revision of the .mg format specification. This revision adds `output_schema` to the Action grain definition phase, introduces the Integration domain profile (`profile:integration`) for REST API connectors and tool catalogs, documents trigger definition conventions via Observation grains, and documents Consensus grain usage patterns for multi-source action definition validation. Submitted as a standards track document for consideration as an IETF RFC and W3C standard. Community feedback is encouraged through issue tracking and discussion forums.
+**Document Status:** This is a v1.3 revision of the .mg format specification. This revision adds `output_schema` to the Tool grain definition phase, introduces the Integration domain profile (`profile:integration`) for REST API connectors and tool catalogs, documents trigger definition conventions via Observation grains, and documents Consensus grain usage patterns for multi-source action definition validation. Submitted as a standards track document for consideration as an IETF RFC and W3C standard. Community feedback is encouraged through issue tracking and discussion forums.
 
 **Last Updated:** 2026-03-03
 **License:** This document is offered under the Open Web Foundation Final Specification Agreement (OWFa 1.0)

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -760,7 +760,7 @@ The `mg:` namespace is reserved for standard semantic relations. Applications de
 | Relation | Typical grain type | Meaning |
 |---|---|---|
 | `mg:perceives` | Observation | Raw sensory or cognitive input |
-| `mg:knows` | Fact | Derived fact or learned fact |
+| `mg:knows` | Fact | Derived or learned fact |
 | `mg:said` | Event | Message or utterance |
 | `mg:did` | Tool | Tool or action invocation |
 | `mg:infers` | Reasoning | Derived conclusion from prior grains |
@@ -865,7 +865,7 @@ Directed graph of procedural steps — plans, pipelines, and multi-path processe
 | Tier | Condition | Resolution |
 |------|-----------|------------|
 | Bound | Node ID present in `bindings` | Fetch the Tool definition grain by hash; use its `tool_name`, `input_schema`, `output_schema` |
-| Named | No binding, but an Tool definition grain exists with matching `tool_name` | Resolve by convention (implementation-defined lookup) |
+| Named | No binding, but a Tool definition grain exists with matching `tool_name` | Resolve by convention (implementation-defined lookup) |
 | Abstract | No binding, no matching tool | Node label is a human-readable instruction; executor (LLM or agent) interprets it |
 
 **Execution record relation:** When an agent executes a workflow node, it creates a Tool grain (phase: complete or call/result) with a relation of type `mg:step_action:<node_id>` targeting the Workflow grain hash. This links execution records to the plan without modifying the immutable Workflow grain.

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1,10 +1,10 @@
 # Open Memory Specification (OMS)
 ## Memory Grain (.mg) Container Definition
 
-**Version:** 1.3
+**Version:** 1.4
 **Status:** Standards Track
 **Category:** Data Formats
-**Date:** February 2026
+**Date:** June 2026
 **Copyright:** Public Domain (CC0 1.0 Universal)
 **License:** This specification is offered under the Open Web Foundation Final Specification Agreement (OWFa 1.0)
 
@@ -68,7 +68,7 @@ A memory grain is the atomic unit of agent knowledge—a single immutable fact, 
 
 The .mg container format is to autonomous systems what JSON is to APIs and .git objects are to version control: a universal, language-agnostic, self-describing interchange format. It is the foundational wire format of OMS.
 
-**CAL (Context Assembly Language)** ([CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md](./CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md)) and **SML (Semantic Markup Language)** ([SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md](./SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md)) are part of OMS v1.3. CAL defines the query and context-assembly layer that operates on OMS stores; SML is CAL's default output format for LLM context consumption. See §1.5 for details.
+**CAL (Context Assembly Language)** ([CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md](./CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md)) and **SML (Semantic Markup Language)** ([SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md](./SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md)) are part of OMS v1.4. CAL defines the query and context-assembly layer that operates on OMS stores; SML is CAL's default output format for LLM context consumption. See §1.5 for details.
 
 ---
 
@@ -138,13 +138,13 @@ OMS addresses this gap by defining a universal standard for knowledge interchang
 
 ### 1.5 Companion Specifications
 
-OMS defines the wire format and grain semantics. Two companion specifications are part of the OMS v1.3 release and are included in this repository:
+OMS defines the wire format and grain semantics. Two companion specifications are part of the OMS v1.4 release and are included in this repository:
 
 **CAL — Context Assembly Language** ([CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md](./CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md))
 
 CAL is a non-destructive, deterministic, LLM-native language for assembling agent context from OMS memory stores. It answers the question: *"what should be in the agent's context window right now?"* Key properties:
 
-- Operates on all 10 OMS grain types (Fact, Event, State, Workflow, Action, Observation, Goal, Reasoning, Consensus, Consent)
+- Operates on all 10 OMS grain types (Fact, Event, State, Workflow, Tool, Observation, Goal, Reasoning, Consensus, Consent)
 - Extends the OMS Store Protocol (§28.4) with a formal, structured query syntax
 - `ASSEMBLE` statements compose context from multiple grain sources within a token budget
 - Append-only: CAL writes create new grains via `put`; the language cannot delete or modify existing grains — this is enforced at the grammar level
@@ -503,7 +503,7 @@ To minimize blob size, human-readable field names are mapped to short keys befor
 | `trigger` | `trigger` | string | Activation condition |
 | `nodes` | `nodes` | array[string] | Graph node IDs/labels |
 | `edges` | `edges` | array[map] | Directed edges (see §8.4 edge schema) |
-| `bindings` | `bind` | map[string→string] | Node ID → Action definition grain hash |
+| `bindings` | `bind` | map[string→string] | Node ID → Tool definition grain hash |
 | `retries` | `retries` | map[string→int] | Node ID → max repeat count |
 
 **Edge nested field compaction:**
@@ -515,11 +515,11 @@ To minimize blob size, human-readable field names are mapped to short keys befor
 | `cond` | `cond` | string |
 | `max_cycles` | `mxc` | int |
 
-### 6.5 Action-Specific Fields
+### 6.5 Tool-Specific Fields
 
 | Full Name | Short Key | Type | Notes |
 |-----------|-----------|------|-------|
-| `action_phase` | `aphase` | string | Discriminator: `"definition"` \| `"call"` \| `"result"` \| absent = complete |
+| `tool_phase` | `aphase` | string | Discriminator: `"definition"` \| `"call"` \| `"result"` \| absent = complete |
 | `tool_name` | `tn` | string | |
 | `input` | `inp` | map | Canonical name for tool arguments (replaces `arguments`) |
 | `content` | `cnt` | any | Canonical name for tool result (replaces `result`) |
@@ -540,7 +540,7 @@ To minimize blob size, human-readable field names are mapped to short keys befor
 | `parent_task_id` | `ptid` | string | Content address of parent task grain |
 | `tool_description` | `tdesc` | string | Human-readable description of the tool (definition phase) |
 | `input_schema` | `isch` | map | JSON Schema for tool inputs; mirrors Anthropic `input_schema` / MCP `inputSchema` (definition phase) |
-| `output_schema` | `osch` | map | JSON Schema (draft-07 compatible) describing the action's return value (definition phase) |
+| `output_schema` | `osch` | map | JSON Schema (draft-07 compatible) describing the tool's return value (definition phase) |
 | `strict` | `strict` | bool | If `true`, model guarantees strict JSON Schema conformance for `input` (definition phase) |
 
 ### 6.6 Observation-Specific Fields
@@ -808,7 +808,7 @@ Directed graph of procedural steps — plans, pipelines, and multi-path processe
 **Optional fields:**
 - `trigger` (string) — condition that activates this workflow
 - `edges` (array[map]) — directed edges between nodes (see edge schema below). When absent, nodes are unconnected.
-- `bindings` (map[string→string]) — maps node IDs to Action definition grain hashes (`action_phase: "definition"`). Unbound nodes are resolved by convention (tool name match) or treated as abstract steps.
+- `bindings` (map[string→string]) — maps node IDs to Tool definition grain hashes (`tool_phase: "definition"`). Unbound nodes are resolved by convention (tool name match) or treated as abstract steps.
 - `retries` (map[string→int]) — maps node IDs to maximum repeat count on failure. Absent means no retry.
 - All common fields.
 
@@ -836,15 +836,15 @@ Directed graph of procedural steps — plans, pipelines, and multi-path processe
 - Node IDs MUST be unique within `nodes`.
 - Unbounded cycles (back-edge without `max_cycles`, and no entry in `retries` for the target node) SHOULD be rejected by implementations.
 
-**Node-to-Action binding** (three-tier resolution):
+**Node-to-Tool binding** (three-tier resolution):
 
 | Tier | Condition | Resolution |
 |------|-----------|------------|
-| Bound | Node ID present in `bindings` | Fetch the Action definition grain by hash; use its `tool_name`, `input_schema`, `output_schema` |
-| Named | No binding, but an Action definition grain exists with matching `tool_name` | Resolve by convention (implementation-defined lookup) |
+| Bound | Node ID present in `bindings` | Fetch the Tool definition grain by hash; use its `tool_name`, `input_schema`, `output_schema` |
+| Named | No binding, but an Tool definition grain exists with matching `tool_name` | Resolve by convention (implementation-defined lookup) |
 | Abstract | No binding, no matching tool | Node label is a human-readable instruction; executor (LLM or agent) interprets it |
 
-**Execution record relation:** When an agent executes a workflow node, it creates an Tool grain (phase: complete or call/result) with a relation of type `mg:step_action:<node_id>` targeting the Workflow grain hash. This links execution records to the plan without modifying the immutable Workflow grain.
+**Execution record relation:** When an agent executes a workflow node, it creates a Tool grain (phase: complete or call/result) with a relation of type `mg:step_action:<node_id>` targeting the Workflow grain hash. This links execution records to the plan without modifying the immutable Workflow grain.
 
 **Example — linear pipeline:**
 
@@ -909,12 +909,12 @@ Directed graph of procedural steps — plans, pipelines, and multi-path processe
 }
 ```
 
-### 8.5 Action (type = 0x05)
+### 8.5 Tool (type = 0x05)
 
-A record of a tool invocation, code execution, or computer-use action. See §27.1 for the full `action_phase` discriminator and field tables.
+A record of a tool invocation, code execution, or computer-use action. See §27.1 for the full `tool_phase` discriminator and field tables.
 
 **Required fields:**
-- `type` = "action"
+- `type` = "tool"
 - Phase-dependent required fields (see §27.1)
 - `created_at` (int64, epoch ms)
 
@@ -2447,11 +2447,11 @@ The `observation_scope` field is a **closed enum**. It describes the temporal br
 
 This section provides detailed field specifications for each standard grain type. For Tool grain phase fields, see §27.1. For Observer types, see §24. For Observation modes/scopes, see §25/§26.
 
-### 27.1 Action Grain (type = 0x05) — Phase and Mode Details
+### 27.1 Tool Grain (type = 0x05) — Phase and Mode Details
 
-The `action_phase` field acts as a discriminator for async vs. synchronous tool call recording.
+The `tool_phase` field acts as a discriminator for async vs. synchronous tool call recording.
 
-**`action_phase` discriminator:**
+**`tool_phase` discriminator:**
 
 | Value | Meaning | Required fields | Absent fields |
 |---|---|---|---|
@@ -2496,8 +2496,8 @@ The `action_phase` field acts as a discriminator for async vs. synchronous tool 
 
 ```json
 {
-  "type": "action",
-  "action_phase": "definition",
+  "type": "tool",
+  "tool_phase": "definition",
   "tool_name": "get_weather",
   "tool_description": "Get the current weather in a given location.",
   "input_schema": {
@@ -2528,7 +2528,7 @@ The `action_phase` field acts as a discriminator for async vs. synchronous tool 
 
 ```json
 {
-  "type": "action",
+  "type": "tool",
   "tool_name": "get_weather",
   "tool_call_id": "toulu_01A09q90qw90lq917835lq9",
   "input": {"location": "San Francisco, CA", "unit": "celsius"},
@@ -2543,7 +2543,7 @@ The `action_phase` field acts as a discriminator for async vs. synchronous tool 
 
 ```json
 {
-  "type": "action",
+  "type": "tool",
   "execution_mode": "code_exec",
   "code": "import pandas as pd\ndf = pd.read_csv('data.csv')\nprint(df.describe())",
   "interpreter_id": "session-abc123",
@@ -2556,7 +2556,7 @@ The `action_phase` field acts as a discriminator for async vs. synchronous tool 
 
 **Alignment with Anthropic API:**
 
-| Anthropic API field | OMS Action field |
+| Anthropic API field | OMS Tool field |
 |---|---|
 | `tool.name` | `tool_name` (definition grain) |
 | `tool.description` | `tool_description` |
@@ -2733,12 +2733,12 @@ Implementations MAY index Observation grains whose `observer_type` starts with `
 }
 ```
 
-### 27.7 Consensus Grain Usage for Action Definition Validation
+### 27.7 Consensus Grain Usage for Tool Definition Validation
 
-When multiple independent sources produce or validate the same Action definition grain, a Consensus grain (type 0x09) records the agreement. This pattern is useful for integration platforms where definitions may be synthesized by LLMs, parsed from OpenAPI specs, validated against reference data, or refined by execution feedback analysis.
+When multiple independent sources produce or validate the same Tool definition grain, a Consensus grain (type 0x09) records the agreement. This pattern is useful for integration platforms where definitions may be synthesized by LLMs, parsed from OpenAPI specs, validated against reference data, or refined by execution feedback analysis.
 
 **Semantics:**
-- `agreed_content` is the content address of the Action definition grain that achieved consensus.
+- `agreed_content` is the content address of the Tool definition grain that achieved consensus.
 - Each entry in `participating_observers` is a DID identifying a validation source.
 - `dissent_grains` link to alternative definitions that did not achieve consensus.
 - Consensus achievement (`agreement_count >= threshold`) serves as a confidence signal for tool catalog quality.
@@ -2759,7 +2759,7 @@ When multiple independent sources produce or validate the same Action definition
   "dissent_count": 1,
   "agreed_content": "<content-address-of-validated-definition-grain>",
   "dissent_grains": ["<content-address-of-alternative-definition>"],
-  "structural_tags": ["consensus:action-definition"],
+  "structural_tags": ["consensus:tool-definition"],
   "namespace": "axtion:connectors:github",
   "related_to": [
     {"hash": "<definition-grain-hash>", "relation_type": "supports", "weight": 1.0}
@@ -2880,7 +2880,7 @@ The `object` map is an open schema. Standard keys:
 |---|---|---|
 | `name` | string | Human-readable agent name |
 | `description` | string | Agent purpose and capabilities summary |
-| `supported_tools` | array[string] | Tool names this agent can invoke (cross-reference with Action definition grains) |
+| `supported_tools` | array[string] | Tool names this agent can invoke (cross-reference with Tool definition grains) |
 | `input_modalities` | array[string] | `"text"`, `"image"`, `"audio"`, `"video"`. What the agent can consume. |
 | `output_modalities` | array[string] | What the agent can produce |
 | `protocol` | string | Communication protocol: `"oms"`, `"mcp"`, `"a2a"`, `"custom"`. Open enum. |
@@ -3209,12 +3209,12 @@ Applies to grains that represent REST API connectors, tool catalog entries, webh
 - `int:response_mapping` MUST be a valid JQ expression if present.
 - `int:rate_limit` is advisory only — enforcement is an implementation concern.
 
-**Example — Action definition with integration profile:**
+**Example — Tool definition with integration profile:**
 
 ```json
 {
-  "type": "action",
-  "action_phase": "definition",
+  "type": "tool",
+  "tool_phase": "definition",
   "tool_name": "github:create-issue",
   "tool_description": "Create a new issue in a GitHub repository",
   "input_schema": {
@@ -3264,7 +3264,7 @@ header-fields = flags-byte type-byte ns-hash-bytes created-at-bytes
                 ; version-byte + header-fields = 9-byte "fixed header" in §3.1
 flags-byte    = %x00-FF
 type-byte     = %x01-0A / %xF0-FF
-                ; Fact=0x01, Event=0x02, State=0x03, Workflow=0x04, Action=0x05,
+                ; Fact=0x01, Event=0x02, State=0x03, Workflow=0x04, Tool=0x05,
                 ; Observation=0x06, Goal=0x07, Reasoning=0x08, Consensus=0x09,
                 ; Consent=0x0A, 0x0B-0xEF reserved, 0xF0-0xFF domain profile types
 ns-hash-bytes = 2OCTET  ; uint16 big-endian, first two bytes of SHA-256(namespace)
@@ -3382,11 +3382,11 @@ footer        = 32OCTET  ; SHA-256 checksum
 }
 ```
 
-**Action-Specific Fields:**
+**Tool-Specific Fields:**
 
 ```json
 {
-  "aphase": "action_phase",
+  "aphase": "tool_phase",
   "tn": "tool_name",
   "inp": "input",
   "cnt": "content",
@@ -3656,7 +3656,7 @@ content_address = sha256(blob).hex()
 
 ---
 
-**Document Status:** This is a v1.3 revision of the .mg format specification. This revision adds `output_schema` to the Tool grain definition phase, introduces the Integration domain profile (`profile:integration`) for REST API connectors and tool catalogs, documents trigger definition conventions via Observation grains, and documents Consensus grain usage patterns for multi-source action definition validation. Submitted as a standards track document for consideration as an IETF RFC and W3C standard. Community feedback is encouraged through issue tracking and discussion forums.
+**Document Status:** This is a v1.4 revision of the .mg format specification. This revision renames grain type `0x01` from `belief` to `fact` and grain type `0x05` from `action` to `tool` (byte values unchanged — existing content addresses remain valid), redesigns the Workflow grain as a directed graph, and adds the `embedding_text` common field for retrieval. Submitted as a standards track document for consideration as an IETF RFC and W3C standard. Community feedback is encouraged through issue tracking and discussion forums.
 
-**Last Updated:** 2026-03-03
+**Last Updated:** 2026-06-12
 **License:** This document is offered under the Open Web Foundation Final Specification Agreement (OWFa 1.0)


### PR DESCRIPTION
## Summary

Cuts the **OMS v1.4** release — brings `main` from **v1.3 → v1.4** — in two logical parts:

1. **belief→fact / action→tool type rename** — renames grain type `0x01` `"belief"` → `"fact"` and `0x05` `"action"` → `"tool"`. Byte values are unchanged, so existing content addresses remain valid; only the type *strings* and prose change.
2. **Skill grain type (`0x0B`)** — adds a dedicated **Skill** cognitive grain for packaged, reusable agent capabilities, promoting the former §28.8 Skill Convention to a first-class grain (Consent §8.10 precedent).

Both ship under **OMS v1.4**. Companion specs are unchanged in version: **CAL v1.1**, **SML v1.0**.

---

## Part 1 — belief→fact / action→tool rename

- **`fact` (0x01)** — the (subject, relation, object) semantic triple with confidence; replaces `belief`.
- **`tool` (0x05)** — records tool/action invocations and executions; replaces `action`.
- Byte values unchanged → existing `.mg` content addresses stay valid. Legacy `"belief"`/`"action"` type strings are **not** accepted.
- Updates the grain-type table, type-specific field headings, relation vocabulary, CAL grammar/closed-set, SML tags, and README throughout.

## Part 2 — Skill grain type (§8.11)

Promotes the former §28.8 *Skill Convention* (a `Fact + mg:capable_of` pattern) to a first-class grain. **Hybrid model:**

**Required:** `name`, `description`, `created_at`

**Optional — definition** (the durable, shareable spec):
`instructions`, `when_to_use`, `version`, `allowed_tools`, `resources`, `dependencies`, `input_modalities`, `output_modalities`, `domain`

**Optional — learned competence** (a given agent's mastery; omit for a pure definition):
`holder_did`, `proficiency`, `practice_count`, `last_practiced_at`, `strategies`, `transferable`

A grain may be a pure **definition** or a held **instance**. Proficiency improvement/decay is recorded by supersession (full history), never in-place mutation. Bundled file payloads reuse the common `content_refs` field.

## Changes by document

- **SPECIFICATION.md** — belief→fact / action→tool rename; §8.11 Skill schema; §3.1 type table; §6.12 Skill-Specific Fields compaction (former Compaction Rules → §6.13); Appendix C block; `mg:capable_of` relation vocab; ABNF/CDDL `type-byte`; glossary; conformance Level 1; reframed §28.8 ("Skill Convention" → "Skill Lifecycle and Transfer") onto the dedicated type. Version 1.3 → 1.4.
- **CAL (v1.1)** — rename across grammar/closed set; `skill`/`skills` added to the closed set; `RECALL skills` field set; `ADD skill` support (required `name`, `description`); content projection; TOON columns; field counts.
- **SML (v1.0)** — rename tags; new `<skill>` element and example.
- **README** — grain-type table, SML tag list, version.
- **CHANGELOG** — `[1.4]` documents the rename, the Workflow-graph redesign / `embedding_text` work already in `main`, and the Skill grain.

## Drive-by fixes (rename leftovers)

While wiring Skill into CAL's type set, fixed stale `belief`/`action` artifacts the rename missed:

- `grain_type_plural` literals (`beliefs`/`actions` → `facts`/`tools`)
- `RECALL MY beliefs` → `RECALL MY facts` (the old keyword is no longer in the closed set)
- TOON column table + examples, and the `DESCRIBE` type listing
- `CAL-E051` message (addable set is now Fact, Observation, Goal, Workflow, Skill)
- a stale `"grain_type": "beliefs"` JSON example

## Compatibility

- **Rename:** breaking at the type-*string* level (`"belief"`/`"action"` rejected); byte values and content addresses unchanged.
- **Skill:** additive type (`0x0B`); no byte reassignments. Existing grains and content addresses remain valid.
