### PR TITLE
OMS 1.6 / CAL 1.3 / SML 1.2 (draft RFC): authorization, anonymization, triggers, and the #12 spec catch-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,24 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 
 ---
 
-## [1.6-draft] — 2026-08-10 (RFC, open for comment)
+## [1.6-draft] — 2026-08-10 (RFC, open for comment; anonymization batch added 2026-08-16)
+
+### Added in the anonymization batch (2026-08-16)
+
+- **OMS §10.5 Pseudonymized Egress**: the placeholder disclosure model for
+  external models; the reserved `anon:<namespace>` policy prefix
+  (write-if-absent replication, fail-closed unreadable rows,
+  minimum-reader-version stamping, keyed value-derived pseudonyms only on
+  encrypted files); the reserved never-replicating `vault:` prefix (sealed
+  under a file-key-derived subkey, erased with the subject, revealed only
+  under grant + fingerprint-only audit); the `anonymized` response report
+  (mapping ids only).
+- **CAL §8.1.2 / §8.2.1 `WITH anonymize("<level>")`**: strengthen-only, on
+  RECALL and per-ASSEMBLE-source — the file-declared policy remains the
+  gate; query text can only add severity.
+- **CAL §8.17 `REHYDRATE`** (Tier 3): the round trip's return leg;
+  classification stated (re-identification is never a plain read), gated,
+  audited by fingerprint; `CAL-E127 MappingUnknown`.
 
 > This entry describes a **draft**. The `release/oms-v1.6` branch is the
 > comment window; nothing below is normative until release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,41 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 
 ---
 
-## [1.6-draft] — 2026-08-10 (RFC, open for comment; anonymization batch added 2026-08-16, trigger batch 2026-08-19)
+## [1.6-draft] — 2026-08-10 (RFC, open for comment; anonymization batch added 2026-08-16, trigger batch 2026-08-19, saved-query batch 2026-08-19)
+
+### Added in the saved-query batch (2026-08-19)
+
+- **CAL §8.18 Saved queries** — `DEFINE QUERY "name"($params) [DESCRIPTION …]
+  AS { body }`, `RUN "name"($p = v)`, `DROP QUERY`, `DESCRIBE QUERIES`. Answers
+  `openmemoryspec/oms#12 §1`: 1.0–1.2 restricted saved-query bodies in four
+  places (§8.14.3, §8.16.1, §8.17, `CAL-E125`) and made `query:<ns>/<name>` a
+  Recommendation target while defining no statement that creates one. Bodies are
+  **Tier 0 only**, non-recursive, and **parsed at definition time with the
+  declared parameters standing in** — a stored query that cannot run is refused
+  where it is written, not left as a landmine for an unattended first caller.
+  Defining is Tier 3 (`admin`); **running is a Tier 0 read**, because the body
+  is structurally read-only and re-verified at execution.
+- **OMS §28.4.1 Host metadata table** — `meta_get`/`meta_put`/`meta_delete`/
+  `meta_scan`, and the reserved prefix registry (`qry:`, `tpl:`, `retention:`,
+  `anon:`, `vault:`, `trg:`). §10.5.1, §10.5.2 and §27.8 already referred to
+  "reserved store-metadata prefixes"; this section is the definition they
+  referenced. Metadata rows are **not grains** — not content-addressed, not
+  returned by a read, no supersession — and replication is per-prefix with the
+  same split the trigger and governance sections draw: *what a definition is*
+  replicates, *where one host got to* does not.
+- **CAL error codes `CAL-E130`–`CAL-E137`** (saved query), and §24's
+  **Definitions module**.
+- **CAL §13 / OMS §28.9** gain the definition-surface and blob rows.
+
+### Changed in the saved-query batch (2026-08-19)
+
+- **`DROP` leaves CAL's §2.4 grammar-exclusion list**, admitted by a production
+  with a closed two-target set (`DROP TEMPLATE`, `DROP QUERY`) that reaches no
+  grain. §2.4 records why the permanence claim survives: what was permanent is
+  the exclusion of unbounded destruction *of memory*, and `DROP` was blocked as
+  the nearest available proxy for that property — this revision replaces the
+  proxy with the property. `UNDEFINE` stays reserved and unspecified rather than
+  becoming a second spelling; implementations MUST NOT accept it as an alias.
 
 ### Added in the trigger batch (2026-08-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ dangerous operations off the books.
   hosts authenticate and resolve principals; grants resolve from the
   memory; credentials never enter grains or statements; owner sessions
   preserve the single-operator experience.
-- **Authorization error codes** CAL-E120–E125, with CAL-E121 messages
+- **Authorization error codes** CAL-E121–E126, with CAL-E121 messages
   naming the missing verb and the `GRANT` that would confer it.
 
 #### CAL 1.3 — Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,85 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 
 ---
 
+## [1.6-draft] — 2026-08-10 (RFC, open for comment)
+
+> This entry describes a **draft**. The `release/oms-v1.6` branch is the
+> comment window; nothing below is normative until release.
+
+### CAL 1.3 — the pillar changes, on purpose and in the open
+
+CAL 1.0–1.2 promised "non-destructive by grammar; no unsafe mode." The
+promise was true and had a hidden cost: real deployments still needed
+erasure — GDPR, retention — so destruction happened anyway, outside the
+language, ungoverned by any spec. Exiling destruction never prevented it; it
+only prevented *specifying* it. 1.3 brings it inside, where grammar bounds
+its shape (whole grains by hash, identity, or age — never a predicate, never
+a key, no history rewrite, no `UNFORGET`), grants gate it per principal, and
+the audit trail sees it. Every 1.0–1.2 document remains valid Tier-0/1 CAL;
+for any session without grants, CAL is still exactly the language those
+releases promised — now the shared floor, not a ceiling that pushed
+dangerous operations off the books.
+
+#### CAL 1.3 — Added
+
+- **Four-tier capability model** (§2.2): Tier 0 Core, Tier 1 Evolve, Tier 2
+  Destroy, Tier 3 Control. **Tiers gate operations, not portability** —
+  interop rides the `.mg` file and Tier-0 reads; a read-only implementation
+  remains fully conformant forever. New `cal_tiers` conformance declaration;
+  `DESCRIBE capabilities` reports the host's tiers.
+- **Tier 2 — Destroy** (§8.14): `FORGET <hash>` (reason optional but
+  recorded), `FORGET SUBJECT <id> [WITH text_mentions] BECAUSE "…"`, and
+  `PURGE OLDER THAN <duration> [TYPE <t>] BECAUSE "…"`. Requires the
+  `delete`/`erase` verbs; fail-closed; one-way; every execution writes an
+  in-memory audit Observation (§8.14.4) following the §8.12.1 audit pattern.
+- **Tier 3 — Control** (§8.15): `GRANT`/`REVOKE` verbs on a namespace for a
+  principal, `SHOW GRANTS`, `DESCRIBE PRINCIPAL` — over grant grains stored
+  in the memory itself (OMS §12.6). `REVOKE` is retraction-by-supersession;
+  grant history is append-only. `DEFINE ROLE` reserved, deferred.
+- **Tier 3 — Governance** (§8.16): `APPROVE`/`REJECT`/`APPLY`/`ROLLBACK`
+  with `BECAUSE` mandatory as *syntax*, `RUN LOOP [FULL]`, and the
+  `DESCRIBE loop|analyzers|outcomes|policy` reads. Self-approval refused
+  against the creating actor and the triggering principal; observer type
+  derives from the principal's host record, never statement text; refused
+  inside `BATCH`, saved queries, and `proposal_cal`. Loop *policy* writes
+  stay permanently outside CAL (self-licensing).
+- **Principal-bound sessions and the credential/policy split** (§18.4):
+  hosts authenticate and resolve principals; grants resolve from the
+  memory; credentials never enter grains or statements; owner sessions
+  preserve the single-operator experience.
+- **Authorization error codes** CAL-E120–E125, with CAL-E121 messages
+  naming the missing verb and the `GRANT` that would confer it.
+
+#### CAL 1.3 — Changed
+
+- §2 Safety Model restated (see narrative above); `FORGET`/`PURGE` and
+  `GRANT`/`REVOKE` moved from the blocked-token list to tier-gated
+  keywords. `DELETE`, `ERASE`, `DESTROY`, `TRUNCATE` and all key/credential
+  vocabulary remain permanently excluded.
+
+### OMS 1.6 — Added
+
+- **§12.6 Authorization**: principals (humans and agents uniformly, DIDs as
+  the signed upgrade path), the closed verb set, namespace-scoped grants;
+  **grant grains** — Facts in the new reserved `agent:authz` namespace
+  (subject = grantee, `mg:permits`, canonical object string, grantor/reason
+  in `context`); effective rights = live heads, fail-closed; revocation by
+  retraction-by-supersession (`mg:revokes` stays consent-domain); owner
+  bootstrap; grants replicate as sync while authoring requires
+  `admin`/owner; the credential/policy split.
+
+### OMS 1.6 — Changed
+
+- §28.4 `delete`: may surface to authorized principals via CAL Tier 2; gains
+  the one-way rule (additions roll back by retraction; erasure is final).
+- §28.9: the "no CAL equivalent — structurally excluded" row now maps to
+  Tier-2 `FORGET`/`PURGE` on hosts that implement them.
+- §8.12 `proposal_cal`: MAY carry Tier-2 statements where the host
+  authorizes destructive proposals (apply recorded not rollbackable);
+  governance statements refused unconditionally.
+
+---
+
 ## [1.5] — 2026-08-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,44 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 
 ---
 
-## [1.6-draft] — 2026-08-10 (RFC, open for comment; anonymization batch added 2026-08-16)
+## [1.6-draft] — 2026-08-10 (RFC, open for comment; anonymization batch added 2026-08-16, trigger batch 2026-08-19)
+
+### Added in the trigger batch (2026-08-19)
+
+- **OMS §8.13 Trigger (type `0x0D`)**: a standing rule that starts a Workflow —
+  interval, calendar schedule, one-shot, polling an external source, a condition
+  over this memory, a host-delivered webhook, a manual dispatch, or a boolean
+  gate over other triggers. Typed, queryable fields; connector transport
+  configuration stays in `config` under the §A.7 `int:` keys. Binding is
+  normatively **trigger → workflow**: a Workflow is content-addressed, so a plan
+  accumulating trigger references would change address whenever one was added.
+- **OMS §27.8 Trigger Execution Contract**: what an implementation that
+  *evaluates* triggers must do — journal every firing, deduplicate on the
+  declared key, seed rather than replay history on first evaluation, keep
+  evaluation state host-local, arbitrate concurrent evaluation through the
+  store, back off on failure, and state its DST semantics rather than assume
+  them. Answers `openmemoryspec/oms#12 §4`.
+- **OMS §17.4 Optional modules** and the `triggers` module declaration,
+  mirroring CAL's tier modules: modules gate operations, not portability.
+- **§A.7 `int:allowed_outbound_hosts`**: the destinations a connector may reach.
+- **CAL: `RECALL triggers`** — the closed grain-type set grows to 13, with a
+  queryable field set (`kind`, `workflow`, `connector`, `scope`, `enabled`,
+  `cron`).
+
+### Removed in the trigger batch (2026-08-19)
+
+- **OMS §27.6 "Trigger Definitions via Observation Grains"** — removed, not
+  deprecated. It was non-conformant against this specification's own closed
+  enums (§25 `observation_mode`, §26 `observation_scope`), its `context`-carried
+  configuration could not be queried, and §24's observer domains have no bucket a
+  standing rule belongs in. Keeping text that instructs implementers to write
+  invalid grains is worse than removing it. §8.13 replaces it, and §27.6 carries
+  a migration note.
+- **`Workflow.trigger` (§8.4)** — **breaking.** A free-text "activation
+  condition" that no implementation evaluated, so it described an activation
+  that could not activate anything. Old blobs are unaffected: an unknown field
+  is preserved and ignored (§19.4). CAL's `ON "…"` clause on `ADD`/`SUPERSEDE
+  workflow` goes with it; `ON` remains a keyword, used by `GRANT`/`REVOKE`.
 
 ### Added in the anonymization batch (2026-08-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 
 ---
 
-## [1.6-draft] — 2026-08-10 (RFC, open for comment; anonymization batch added 2026-08-16, trigger batch 2026-08-19, saved-query and template-identity batches 2026-08-19)
+## [1.6-draft] — 2026-08-10 (RFC, open for comment; anonymization batch added 2026-08-16, trigger batch 2026-08-19, saved-query, template-identity and blob-lifecycle batches 2026-08-19)
 
 ### Added in the saved-query batch (2026-08-19)
 
@@ -44,6 +44,35 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
   the nearest available proxy for that property — this revision replaces the
   proxy with the property. `UNDEFINE` stays reserved and unspecified rather than
   becoming a second spelling; implementations MUST NOT accept it as an alias.
+
+### Added in the blob-lifecycle batch (2026-08-19)
+
+- **OMS §7.1.1 the `cas:` URI scheme** — `cas://sha256:<64-hex>`, used once as
+  an example URI since 1.0 and never defined. The address is the SHA-256 of the
+  **plaintext** bytes (so content addresses identically in an encrypted memory
+  and a plaintext one), a reader MUST verify it, resolution is memory-local and
+  never a network fetch, a reference is **not** a promise of presence, and a
+  malformed address fails closed before any lookup. Answers
+  `openmemoryspec/oms#12 §5`.
+- **OMS §28.4 `put_blob` / `get_blob`** — the operation table was grains-only.
+  `put_blob` is idempotent by construction (the address *is* the content);
+  `get_blob` verifies the digest before returning bytes.
+- **OMS §28.4.2 Blob concurrency** — a blob read needs no lock, because an
+  immutable object whose address is its checksum poses no consistency question.
+  Stated normatively because the alternative starves real callers: where a
+  memory lock is exclusive, a run holding the memory would otherwise block the
+  subprocess it spawned to process an attachment, for a lock protecting nothing.
+- **OMS §28.4.3 Blob lifecycle under erasure** — the GDPR-grade half.
+  Sole-referenced attachments MUST be reclaimed by subject erasure; reclamation
+  MUST be **targeted, never a store-wide sweep** (a census races an upload that
+  has happened while its referencing grain has not, and collecting it destroys
+  an unrelated caller's data); the surviving-reference check MUST run under the
+  erasure's own serialization; the report MUST count reclaimed blobs separately;
+  and crypto-erasure MUST reach blobs, since encrypting the database while
+  leaving attachments in the clear beside it encrypts the index and publishes
+  the documents. The byte-identical-concurrent-upload window is stated rather
+  than implied.
+- **CAL §8.14.1** carries the same obligation onto `FORGET SUBJECT`.
 
 ### Added in the template-identity batch (2026-08-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 
 ---
 
-## [1.6-draft] — 2026-08-10 (RFC, open for comment; anonymization batch added 2026-08-16, trigger batch 2026-08-19, saved-query, template-identity, blob-lifecycle, subject-reachability and mail-profile batches 2026-08-19)
+## [1.6-draft] — 2026-08-10 (RFC, open for comment; anonymization batch added 2026-08-16, trigger batch 2026-08-19, saved-query, template-identity, blob-lifecycle, subject-reachability, mail-profile and housekeeping batches 2026-08-19)
 
 ### Added in the saved-query batch (2026-08-19)
 
@@ -44,6 +44,34 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
   the nearest available proxy for that property — this revision replaces the
   proxy with the property. `UNDEFINE` stays reserved and unspecified rather than
   becoming a second spelling; implementations MUST NOT accept it as an alias.
+
+### Fixed in the housekeeping batch (2026-08-19)
+
+Answers `openmemoryspec/oms#12 §7`.
+
+- **`mg:step_action:<node_id>` joins the relation vocabularies** (OMS §8, CAL
+  §7.1). It was used normatively in §8.4 while appearing in no vocabulary list,
+  so a conformant validator warned `CAL-W001` — "unknown `mg:` relation" — on
+  this specification's own relation. It is the first **parameterized** standard
+  relation (the node id is part of the value), so CAL §7.3 now states the
+  matching rule: parameterized rows match by prefix, everything else by exact
+  value.
+- **CAL §14.3 had two disclosure models and admitted one.** The grammar has read
+  `disclosure_level = "summary" | "headlines" | "full"` since 1.0, against a
+  §14.3 table naming `summary | standard | full`. They were never the same
+  control: one is **metadata density** (how many attributes an element carries),
+  the other is **body extent** (how much free text survives). §14.3 now
+  documents both axes and how they compose, including that `full` is *additive*
+  — it carries a Skill's `instructions`/`when_to_use`, which no other level
+  does at any budget — and that omitting the option is **not** a level but a
+  request to leave each format's established output alone.
+- **Version markers reconciled.** `SPECIFICATION.md`'s footer said "the v1.5
+  revision" under a 1.6-draft header; it now describes the 1.6 draft, and the
+  byte-range sentence reads `0x01`–`0x0C` unchanged (Trigger takes `0x0D`).
+  Footer dates across all three documents moved to 2026-08-19.
+- **`CONTRIBUTING.md` pointed at `oms-specification.md`**, a file that has never
+  existed in this repository. The checklist now names the three documents that
+  do, and asks for the changelog entry.
 
 ### Added in the mail-profile batch (2026-08-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 
 ---
 
-## [1.6-draft] — 2026-08-10 (RFC, open for comment; anonymization batch added 2026-08-16, trigger batch 2026-08-19, saved-query, template-identity and blob-lifecycle batches 2026-08-19)
+## [1.6-draft] — 2026-08-10 (RFC, open for comment; anonymization batch added 2026-08-16, trigger batch 2026-08-19, saved-query, template-identity, blob-lifecycle and subject-reachability batches 2026-08-19)
 
 ### Added in the saved-query batch (2026-08-19)
 
@@ -44,6 +44,32 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
   the nearest available proxy for that property — this revision replaces the
   proxy with the property. `UNDEFINE` stays reserved and unspecified rather than
   becoming a second spelling; implementations MUST NOT accept it as an alias.
+
+### Added in the subject-reachability batch (2026-08-19)
+
+- **OMS §28.4.4 Subject reachability** — prior revisions defined the erasure
+  selector without ever saying what it must **reach**, and a conforming
+  implementation was found to under-erase silently because of it: a grain
+  carrying a `subject` but no relation or object reached no structural index, so
+  the identity's own transcript survived an erasure **that reported success**
+  and went undisclosed in a DSAR **that reported completeness**. Now normative:
+  reachability is a property of the identity, not of grain shape; reach extends
+  to object position, session/run keys and partition-key derivatives; **erasure
+  and disclosure MUST share one selector**; a known-incomplete scope MUST NOT
+  report success; a reachability fix MUST heal existing memories by index
+  rebuild rather than only indexing correctly going forward; residual limits
+  MUST be documented. Carries a **required conformance case** — store a grain
+  with only a subject, assert it is reported and then erased. Answers
+  `openmemoryspec/oms#12 §6`.
+- **CAL §8.19 `REPORT SUBJECT`** — the read-only mirror of `FORGET SUBJECT`,
+  and the statement §28.4.4 rule 3 is about. Tier 0, `read` verb, same selector
+  and same `WITH text_mentions` precondition as the erasure. It MUST NOT sit
+  behind the cap that disables destructive operations — a deployment that turned
+  destruction off still owes data subjects access — and it writes **no** audit
+  grain: access destroys nothing, and an audit grain naming the subject of a
+  DSAR would itself be personal data about them in an immutable replicating
+  store. GDPR Art. 15/20 in §19.2 now point at it instead of at a `RECALL`
+  approximation.
 
 ### Added in the blob-lifecycle batch (2026-08-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@ Answers `openmemoryspec/oms#12 §7`.
   revision" under a 1.6-draft header; it now describes the 1.6 draft, and the
   byte-range sentence reads `0x01`–`0x0C` unchanged (Trigger takes `0x0D`).
   Footer dates across all three documents moved to 2026-08-19.
+- **Duplicate section number `§6.14`.** The trigger batch added "§6.14
+  Trigger-Specific Fields" without renumbering the "§6.14 Compaction Rules" that
+  followed it — the same bump the Recommendation type did on its way in.
+  Compaction Rules is now §6.15; nothing referenced it by number.
 - **`CONTRIBUTING.md` pointed at `oms-specification.md`**, a file that has never
   existed in this repository. The checklist now names the three documents that
   do, and asks for the changelog entry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 
 ---
 
-## [1.6-draft] — 2026-08-10 (RFC, open for comment; anonymization batch added 2026-08-16, trigger batch 2026-08-19, saved-query batch 2026-08-19)
+## [1.6-draft] — 2026-08-10 (RFC, open for comment; anonymization batch added 2026-08-16, trigger batch 2026-08-19, saved-query and template-identity batches 2026-08-19)
 
 ### Added in the saved-query batch (2026-08-19)
 
@@ -44,6 +44,29 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
   the nearest available proxy for that property — this revision replaces the
   proxy with the property. `UNDEFINE` stays reserved and unspecified rather than
   becoming a second spelling; implementations MUST NOT accept it as an alias.
+
+### Added in the template-identity batch (2026-08-19)
+
+- **OMS §28.4.1 definition identity** — every stored definition (`qry:`, `tpl:`)
+  carries **two** stamps that an implementation MUST NOT collapse: `updated_at`
+  (the latest-wins replication tiebreaker and the "when did this change") and
+  `definition_hash` (SHA-256 over the NFC-normalized body — the stable identity
+  of *this* revision). Neither substitutes for the other: a timestamp cannot
+  identify a revision (two hosts editing to the same body get different stamps
+  for identical content), and a hash cannot order revisions. Answers
+  `openmemoryspec/oms#12 §2`.
+- **CAL §10.6.3 Template identity, revision, and `DROP TEMPLATE`** — templates
+  are stored definitions under `tpl:<name>` on §8.18.1's terms; both stamps are
+  reported by `DESCRIBE TEMPLATES`; built-ins are code, not metadata, and are
+  neither droppable nor persistable; dropping a template another template
+  `EXTENDS` is refused rather than left dangling.
+- **`template:<ns>/<name>@<definition_hash>`** — Recommendation targets may be
+  revision-qualified, and a Recommendation applied to a definition MUST record
+  the **replaced body** on its applied audit grain, so its inverse reinstates
+  the revision it displaced rather than "whatever was there before". §8.12
+  rule 4 additionally asks `summary.template_id` to carry its revision: a bare
+  name renders a summary whose text can silently change after a reviewer
+  approved it.
 
 ### Added in the trigger batch (2026-08-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
 
 ---
 
-## [1.6-draft] — 2026-08-10 (RFC, open for comment; anonymization batch added 2026-08-16, trigger batch 2026-08-19, saved-query, template-identity, blob-lifecycle and subject-reachability batches 2026-08-19)
+## [1.6-draft] — 2026-08-10 (RFC, open for comment; anonymization batch added 2026-08-16, trigger batch 2026-08-19, saved-query, template-identity, blob-lifecycle, subject-reachability and mail-profile batches 2026-08-19)
 
 ### Added in the saved-query batch (2026-08-19)
 
@@ -44,6 +44,35 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Ver
   the nearest available proxy for that property — this revision replaces the
   proxy with the property. `UNDEFINE` stays reserved and unspecified rather than
   becoming a second spelling; implementations MUST NOT accept it as an alias.
+
+### Added in the mail-profile batch (2026-08-19)
+
+- **OMS Appendix A.8 Mail Profile (`mail:`)** — `mail:message_id`,
+  `mail:in_reply_to`, `mail:references`, `mail:from`/`to`/`cc`/`bcc`,
+  `mail:subject`, `mail:date`, `mail:folder`, `mail:direction`,
+  `mail:transport`, plus a normative RFC 5322 → OMS field mapping. Event grains
+  model LLM turns — `role` is a chat enum — and nothing in the specification
+  named a sender, recipient, subject line or `Message-ID`, so every mail-shaped
+  agent invented its own `context` keys and lost portability on exactly the
+  grains most worth porting. Answers `openmemoryspec/oms#12 §3` by its option
+  (a). Option (b), a first-class `thread_id` common field, was **rejected**: it
+  adds a compact key to a normative frozen field map for a concept `session_id`
+  already carries. The thread *is* the session (§28.6); `In-Reply-To` maps to
+  both `parent_message_id` (the parent grain's content address) and
+  `mail:in_reply_to` (the transport id — the only form available when the
+  parent was never ingested).
+- Two prohibitions carry privacy weight: `mail:message_id` MUST NOT be used as
+  or derived into a content address, and `mail:bcc` MUST NOT be populated from a
+  *received* message. A correspondent an agent asserts facts about SHOULD also
+  appear in `subject`, because §28.4.4 reaches structured references — a person
+  reachable only through a `context` key is not reachable by erasure or DSAR.
+- **CAL `domain_prefix` admits `mail`** — the production is closed by design (an
+  open prefix would turn every misspelled field into a valid domain field
+  instead of `CAL-E004`), so a new OMS profile needs this CAL change to be
+  queryable.
+- **Status:** this is the one part of the 1.6 draft written *ahead of* a
+  reference implementation rather than from working code, and it says so in the
+  spec. The field set is a starting point for comment.
 
 ### Added in the subject-reachability batch (2026-08-19)
 

--- a/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
+++ b/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
@@ -1426,7 +1426,11 @@ PURGE OLDER THAN 30d TYPE event BECAUSE "transcript TTL"    -- age + one grain t
 - All three are **one-way** (§2.3): there is no `UNFORGET`, and a host MUST
   NOT offer an un-tombstone or un-erase mechanism through any interface.
 - An erasure execution SHOULD produce the host's erasure report; the audit
-  Observation (§8.14.4) references it.
+  Observation (§8.14.4) references it. Where the erased grains referenced
+  content-addressed attachments, erasure MUST also reclaim the ones no
+  surviving grain references, and the report MUST carry that count separately
+  from the grain count (OMS §28.4.3). A statement that erased a subject's
+  grains and left the subject's documents on disk has not erased the subject.
 
 #### 8.14.2 Authorization
 

--- a/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
+++ b/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
@@ -551,7 +551,9 @@ verb_list       = verb , { "," , verb } ;
 verb            = "read" | "write" | "supersede" | "delete" | "erase"
                 | "loop.run" | "loop.review" | "loop.apply" | "admin" ;
 ns_scope        = identifier | string_literal | "*" ;
-principal       = identifier , ":" , identifier | string_literal ;
+principal       = string_literal ;   (* e.g. "agent:support-bot" — quoted:
+                                        principal names carry ":" and "-",
+                                        which identifiers do not *)
 
 approve_stmt    = "APPROVE"  , ( hash_literal | parameter ) , reason_clause ;
 reject_stmt     = "REJECT"   , ( hash_literal | parameter ) , reason_clause ;
@@ -1353,9 +1355,9 @@ Grants are stored **in the memory itself** as grant grains (OMS §12.6) --
 they travel, replicate, and are queryable like any other memory.
 
 ```sql
-GRANT read, write ON caller TO agent:support-bot
-GRANT delete ON * TO user:anna WITH because("support rotation")
-REVOKE write ON caller FROM agent:support-bot WITH because("offboarded")
+GRANT read, write ON caller TO "agent:support-bot"
+GRANT delete ON * TO "user:anna" WITH because("support rotation")
+REVOKE write ON caller FROM "agent:support-bot" WITH because("offboarded")
 SHOW GRANTS                          -- every live grant
 SHOW GRANTS FOR agent:support-bot    -- one principal's live grants
 DESCRIBE PRINCIPAL agent:support-bot -- effective verbs per namespace
@@ -2624,7 +2626,7 @@ in the session executes *as* that principal.
   (tokens, passwords, OS identity) to principal *names*; the memory's grant
   grains (OMS §12.6) map principal names to *rights*. Credentials MUST NOT
   be carried in grains, in CAL statements, or in the memory file in any
-  form. A CAL statement can name a principal (`GRANT ... TO agent:x`); it
+  form. A CAL statement can name a principal (`GRANT ... TO "agent:x"`); it
   can never mint, present, or reveal a credential.
 - **The boundary rule.** Anything that needs a filesystem path, a
   credential, or a process to exist is a host operation; everything that

--- a/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
+++ b/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
@@ -156,7 +156,7 @@ The guarantee is enforced at three reinforcing levels:
 | **0** | Core (default) | Query, count, explain, assemble, describe, batch. Cannot modify anything. | None. Default for all CAL sessions. |
 | **1** | Evolve (opt-in) | Add new grains, supersede, revert, view history. Append-only; never deletes. | Server opt-in; `write`/`supersede` verbs where Tier 3 is implemented, capability token with write quotas otherwise. |
 | **2** | Destroy | `FORGET <hash>`, `FORGET SUBJECT`, `PURGE OLDER THAN`. Whole-grain tombstone and bulk erasure -- one-way, audited. | `delete`/`erase` verbs. Requires *an* authorization model: host-defined authorization suffices (Tier 2 without Tier 3 is legal). A host with no authorization model MUST refuse Tier 2. |
-| **3** | Control | `GRANT`/`REVOKE` (DCL), the governance lifecycle (`APPROVE`/`REJECT`/`APPLY`/`ROLLBACK`/`RUN LOOP`), principal-bound sessions. | `admin` and `loop.*` verbs; implies the grant model (OMS §12.6) that Tier 2 consumes. |
+| **3** | Control | `GRANT`/`REVOKE` (DCL), the governance lifecycle (`APPROVE`/`REJECT`/`APPLY`/`ROLLBACK`/`RUN LOOP`), the definition surface (`DEFINE QUERY`/`DROP QUERY`, `DEFINE TEMPLATE`/`DROP TEMPLATE`), principal-bound sessions. | `admin` and `loop.*` verbs; implies the grant model (OMS §12.6) that Tier 2 consumes. |
 
 **Tiers gate operations, not portability.** Interoperability rides the `.mg` file and Tier-0 reads: any Core implementation can read any memory. A read-only implementation declares Tier 0 and remains fully conformant forever -- nothing in Tier 2/3 is required of it. Hosts declare their tiers, and `DESCRIBE capabilities` MUST report them, so an agent (or a test suite) learns what it may attempt before attempting it.
 
@@ -185,7 +185,7 @@ The guarantee is enforced at three reinforcing levels:
 The following tokens do **not exist** in CAL's lexer or grammar, at any tier:
 
 ```
-DELETE, DROP, ERASE, DESTROY, TRUNCATE,                     -- Predicate/unbounded destruction
+DELETE, ERASE, DESTROY, TRUNCATE,                           -- Predicate/unbounded destruction
 INSERT, CREATE, WRITE, STORE,                               -- Unconstrained creation
 KEY, ENCRYPT, DECRYPT, ROTATE, MASTER, DEK, SECRET, TOKEN,  -- Key/credential management
 POLICY, SEAL, UNSEAL, CONSENT, RESTRICT,                    -- Sealed policy / consent records
@@ -195,6 +195,25 @@ SCHEMA, PARTITION, INDEX, MIGRATION                         -- Schema
 If these appear in a query, they are parse errors, not recognized keywords. This list is permanent: no future tier unblocks it. (`POLICY` here means the sealed policy and loop-policy *writes*; the read-only `DESCRIBE policy` target is an identifier, not this keyword.)
 
 **Changed in 1.3:** `FORGET` and `PURGE` moved from this list to the Tier 2 keyword set, and `GRANT`/`REVOKE` to the Tier 3 keyword set (§3.2). The block on them existed to force a specification-level decision before any destructive or control surface entered the language -- this revision is that decision, and the statements it admits are bounded by §2.1--§2.3.
+
+**Also changed in 1.3 -- `DROP`, and why the permanence claim survives it.**
+`DROP` leaves this list, admitted by a production with a **closed two-target
+set**: `DROP TEMPLATE` (§10.6.3) and `DROP QUERY` (§8.18.4). Neither target is
+memory. A template and a saved query are *host metadata* -- definitions the
+memory carries so they travel with the file (OMS §28.4.1), never grains, never
+content-addressed, never returned by a read. There is no production by which
+`DROP` reaches a grain, so the claim this list encodes -- that no CAL statement
+destroys memory outside the audited, authorization-gated Tier-2 shapes -- is
+unchanged. What was permanent was the exclusion of unbounded destruction *of
+memory*; the token was blocked as the nearest available proxy for that, and
+this revision replaces the proxy with the property itself. Removing a
+definition is idempotent and lossless against memory: every grain the query
+ever recalled is still there, and re-running the `DEFINE` restores it exactly.
+
+`UNDEFINE` remains reserved (Appendix D) and unspecified. It was held for these
+semantics; `DROP TEMPLATE`/`DROP QUERY` are the spelling that shipped, so
+`UNDEFINE` stays reserved rather than becoming a second one -- an
+implementation MUST NOT accept it as an alias.
 
 Note: Tier 1/2/3 keywords are always **parsed** (so `EXPLAIN FORGET ...` works as a dry-run even where execution is unavailable). The **executor** rejects non-EXPLAIN statements above the session's effective tier: `CAL-E044: Tier1NotEnabled` for Tier 1, `CAL-E121`/`CAL-E122` for Tier 2/3 (§22). This two-layer approach ensures `EXPLAIN` can always preview an operation without risk.
 
@@ -240,8 +259,14 @@ FORGET, PURGE, SUBJECT, OLDER, THAN, TYPE, BECAUSE
 **Tier 3 (Control) keywords (new in 1.3; always parsed; execution requires the `admin`/`loop.*` verbs -- see sections 8.14 and 8.15):**
 ```
 GRANT, REVOKE, ON, TO, SHOW, GRANTS, PRINCIPAL,
-APPROVE, REJECT, APPLY, ROLLBACK, RUN, LOOP, FULL
+APPROVE, REJECT, APPLY, ROLLBACK, RUN, LOOP, FULL,
+QUERY, QUERIES, DESCRIPTION, DROP                         -- definition surface (§8.18, §10.6.3)
 ```
+
+`RUN` serves two statements distinguished by their next token: `RUN LOOP`
+(§8.16) and `RUN "<name>"` (§8.18.3). A saved query name is a **string
+literal**, so the two never collide -- `LOOP` is a keyword and can never be a
+quoted name.
 
 `BECAUSE` was already an alias of `REASON` in `reason_clause`; Tier 2/3 statements conventionally write `BECAUSE`, and this specification uses that spelling for them throughout. `DEFINE ROLE` is **reserved but not specified** in 1.3 -- role bundles are deferred to a future revision; the 1.3 grant surface is verbs-only.
 
@@ -316,12 +341,14 @@ extractor       = "SUBJECTS" | "OBJECTS" | "HASHES" ;
 
 statement       = explain_stmt | recall_stmt | assemble_stmt | set_stmt
                 | exists_stmt | history_stmt | describe_stmt | batch_stmt
-                | coalesce_stmt | define_template_stmt
+                | coalesce_stmt | run_query_stmt
                 | add_stmt | supersede_stmt | revert_stmt
                 | forget_stmt | purge_stmt                        (* Tier 2 *)
                 | grant_stmt | revoke_stmt | show_grants_stmt     (* Tier 3 *)
                 | approve_stmt | reject_stmt | apply_stmt
                 | rollback_stmt | run_loop_stmt
+                | define_template_stmt | drop_template_stmt       (* Tier 3 *)
+                | define_query_stmt | drop_query_stmt             (* Tier 3 *)
                 | rehydrate_stmt ;                                (* Tier 3 *)
 
 (* --- Tier 0: Read --- *)
@@ -565,6 +592,24 @@ reject_stmt     = "REJECT"   , ( hash_literal | parameter ) , reason_clause ;
 apply_stmt      = "APPLY"    , ( hash_literal | parameter ) , reason_clause ;
 rollback_stmt   = "ROLLBACK" , ( hash_literal | parameter ) , reason_clause ;
 run_loop_stmt   = "RUN" , "LOOP" , [ "FULL" ] , [ with_clause ] ;
+
+(* --- Tier 3: the definition surface (new in 1.3) --- *)
+
+define_query_stmt = "DEFINE" , "QUERY" , query_name ,
+                    [ "(" , param_decl , { "," , param_decl } , ")" ] ,
+                    [ "DESCRIPTION" , string_literal ] ,
+                    "AS" , "{" , query_body , "}" ;
+param_decl        = parameter , [ "=" , value ] ;
+query_body        = statement ;   (* Tier 0 only -- §8.18.2 *)
+query_name        = string_literal ;
+
+drop_query_stmt    = "DROP" , "QUERY" , query_name ;
+drop_template_stmt = "DROP" , "TEMPLATE" , ( template_name | string_literal ) ;
+
+(* RUN of a saved query is Tier 0: it classifies as its body does (§8.18.3). *)
+run_query_stmt    = "RUN" , query_name ,
+                    [ "(" , param_bind , { "," , param_bind } , ")" ] ;
+param_bind        = parameter , "=" , value ;
 
 (* --- Workflow graph syntax --- *)
 
@@ -1531,6 +1576,166 @@ model echoing them.
 Refused inside `BATCH`, saved-query bodies, and `proposal_cal`, like every
 Tier 2/3 statement (Section 8.14.3).
 
+### 8.18 Saved queries (Tier 3 to define, Tier 0 to run -- new in 1.3)
+
+A **saved query** is a named, parameterized CAL body stored with the memory and
+executed by name. It exists so that prompt-assembly logic -- which `ASSEMBLE`
+runs on every turn, and which is edited far more often than the agent around it
+-- can live as a definition the memory carries rather than as a string literal
+compiled into a host.
+
+Versions 1.0--1.2 restricted saved-query bodies in four places (§8.14.3,
+§8.16.1, §8.17, `CAL-E125`) and made `query:<namespace>/<name>` a valid
+Recommendation `target_ref` (OMS §8.12) while defining no statement that
+creates one. This section is the missing definition; the restrictions that
+referenced it are unchanged and now have a referent.
+
+#### 8.18.1 Definitions are host metadata, not memory
+
+A saved query is **not a grain.** It is not content-addressed, it is not
+returned by `RECALL`, it does not participate in supersession, and defining one
+writes no grain. It is host metadata carried in the memory's own metadata table
+(OMS §28.4.1) under the reserved key prefix `qry:<name>`, one row per
+definition.
+
+That placement is the substantive design decision, and it is deliberate on both
+sides:
+
+- **Carried by the memory, not the client.** A saved query travels with the
+  `.mg` file. Every surface opening that memory -- CLI, MCP server, console,
+  language bindings -- sees the same set, so "which queries exist" is a
+  property of the memory rather than of whichever process happens to be asking.
+- **Not memory.** A definition is configuration. Making it a grain would put
+  editable operational config into an immutable, content-addressed,
+  replicating, erasure-relevant structure, and would put a query body into
+  every `RECALL` that did not ask for one.
+
+**Replication (normative).** Definitions MUST replicate with the memory (bundle
+and stream export/import), converging **latest-wins** on the definition's
+update time. Usage state MUST NOT replicate: a `last_run_at`-style
+last-execution stamp is a record of what one host did, not of what the
+definition *is*, and an incoming update MUST leave the local stamp intact. This
+is the same split §27.8 draws for triggers and §8.12 draws for governance
+state: **what a definition is replicates; where one host got to does not.**
+
+A point-in-time restore reconstructs grain history and MUST skip the
+definition registry -- a restore to last Tuesday is a statement about memory,
+not an instruction to revert an operator's query edits -- and MUST report that
+it did.
+
+An entry the running implementation cannot load (written by a newer revision,
+or against a limit since tightened) MUST be skipped with a warning rather than
+failing the open, and MUST be left in the file so another implementation can
+still read it.
+
+#### 8.18.2 DEFINE QUERY
+
+```sql
+DEFINE QUERY "session_prompt"($user, $session, $n = 10)
+  DESCRIPTION "standard session bootstrap"
+AS {
+  ASSEMBLE "session" FROM
+    profile: (RECALL facts  WHERE subject = $user),
+    recent:  (RECALL events WHERE session_id = $session RECENT $n)
+  BUDGET 1200 FORMAT sml
+}
+```
+
+Normative rules:
+
+1. **Bodies are Tier 0 only.** A body MUST contain exactly one statement, and
+   that statement MUST classify as Tier 0 (read). A Tier 1/2/3 statement in a
+   body is refused at definition time (`CAL-E136`). This is what makes `RUN`
+   itself a read (§8.18.3), and it is why the Tier-2/3 context restrictions
+   (§8.14.3) can name saved-query bodies without further qualification.
+2. **No recursion.** A body MUST NOT contain `RUN` (`CAL-E135`). Bodies compose
+   through subqueries and `ASSEMBLE` sources, not through each other; this
+   makes execution cost analyzable from the body's own text.
+3. **Define-time validation MUST parse the body as it would run.** An
+   implementation MUST parse the body at definition time, with the declared
+   parameters standing in at their call-site positions, and refuse a body that
+   fails (`CAL-E137`). A body whose parameter sits where the grammar demands a
+   literal (`RECENT $n`) is valid: the check substitutes before parsing, so
+   only a body that is malformed *however* it is bound is refused.
+
+   This rule is normative because of who pays for its absence. A stored query
+   that cannot parse is a latent failure whose first caller is typically an
+   unattended agent, long after its author has moved on. Validation at
+   definition time turns that into an error for the person who can still fix
+   it.
+4. **Redefinition replaces.** `DEFINE QUERY` on an existing name replaces the
+   definition and updates its revision stamp; it is not an error. There is no
+   definition history -- a saved query is configuration, and its audit trail is
+   the Recommendation lifecycle (OMS §8.12) where a governed change produced
+   it.
+5. **Authorization.** `DEFINE QUERY` and `DROP QUERY` are Tier 3 and require
+   the `admin` verb for the target namespace. A definition is executed by
+   principals who may not be permitted to write it; that gap is the point.
+6. **Verification is not one-shot.** An implementation MUST re-verify the
+   read-only property when the body executes, not only when it is defined. A
+   definition can arrive by replication from a peer running a different
+   revision, so a definition-time check alone is a check the attacker chooses
+   the timing of.
+
+**Limits.** An implementation MUST enforce, and `DESCRIBE capabilities` SHOULD
+report:
+
+| Constraint | Limit |
+|---|---|
+| Max saved queries per namespace | 100 |
+| Max query body size | 8192 bytes |
+| Max declared parameters | 10 |
+| Query name | string literal, 64 characters |
+
+Exceeding them is `CAL-E131` / `CAL-E132` / `CAL-E133`.
+
+A parameter MAY declare a default (`$n = 10`). A parameter without a default is
+required at the call site.
+
+#### 8.18.3 RUN
+
+```sql
+RUN "session_prompt"($user = "john", $session = "call-42")
+```
+
+`RUN "<name>"` binds arguments to the declared parameters and executes the
+body. A parameter with neither an argument nor a default is `CAL-E134`; an
+unknown name is `CAL-E130`.
+
+**`RUN` classifies as its body does.** Because bodies are structurally Tier 0
+(§8.18.2 rule 1, re-verified at execution by rule 6), running a saved query is
+a **read**, requires only the `read` verb, and is available wherever `RECALL`
+is. An implementation MUST NOT gate `RUN` behind the `admin` verb that
+`DEFINE QUERY` requires: defining is control, running is reading, and
+collapsing the two would make every consumer of a saved query an
+administrator.
+
+Substitution happens **before** parsing, so an implementation caching parsed
+statements by text reuses a plan per distinct argument set, and a
+zero-parameter saved query hits that cache on every call after the first.
+Values bind as values, not as text splices: a bound argument can never
+introduce a token, so no argument can change the body's classification.
+
+#### 8.18.4 DROP QUERY and DESCRIBE QUERIES
+
+```sql
+DROP QUERY "session_prompt"
+DESCRIBE QUERIES
+```
+
+`DROP QUERY` removes a definition. It is Tier 3 (`admin`), it touches no grain,
+and it is lossless against memory (§2.4). Dropping an absent name is
+`CAL-E130`.
+
+`DESCRIBE QUERIES` is Tier 0 and lists the registered definitions -- name,
+description, parameter count, body size, revision stamp, and last-execution
+stamp where the host keeps one. It is the discovery surface an agent uses to
+find what it may `RUN`.
+
+`DESCRIBE capabilities` SHOULD report saved-query support and the limits of
+§8.18.2.
+
+
 ---
 
 ## 9. Semantic Shortcuts
@@ -2339,6 +2544,10 @@ Every CAL statement maps to one or more OMS Store Protocol operations (OMS §28.
 | REVERT | 3 | 4 | `get` + `get` + `supersede` |
 | Set operation | 2 | 2 | One query per operand |
 | ASSEMBLE | N | N | N x `query`/`search` (one per source) |
+| DEFINE QUERY / DROP QUERY | 1 | 1 | `meta_put` / `meta_delete` (OMS §28.4.1) -- no grain operation |
+| DEFINE TEMPLATE / DROP TEMPLATE | 1 | 1 | `meta_put` / `meta_delete` (OMS §28.4.1) -- no grain operation |
+| RUN "<name>" | 1 | N | `meta_get` + the body's own operations |
+| DESCRIBE QUERIES / TEMPLATES | 1 | 1 | `meta_scan` (OMS §28.4.1) |
 
 ---
 
@@ -2915,7 +3124,8 @@ See [Appendix C](#appendix-c-error-code-registry) for the complete registry. Err
 | CAL-E085 -- CAL-E096 | Template | 12 |
 | CAL-E100 | Version | 1 |
 | CAL-E110, CAL-E113 | Multi-Format | 2 |
-| CAL-E121 -- CAL-E126 | Authorization (Tier 2/3, new in 1.3) | 6 |
+| CAL-E121 -- CAL-E127 | Authorization (Tier 2/3, new in 1.3) | 7 |
+| CAL-E130 -- CAL-E137 | Saved query (new in 1.3) | 8 |
 
 ### 22.3 Warning Codes
 
@@ -3028,6 +3238,13 @@ Orthogonal to Levels 1--4, the Tier 2/3 statement families are optional
   over in-memory grant grains (OMS §12.6); principal-bound sessions
   (§18.4); the governance statements (§8.16) where the host has a
   recommendation engine. Implies the grant model Tier 2 consumes.
+- **Definitions (Tier 3 to write, Tier 0 to read):** `DEFINE QUERY`/`DROP
+  QUERY`/`RUN`/`DESCRIBE QUERIES` (§8.18) and `DEFINE TEMPLATE`/`DROP
+  TEMPLATE`/`DESCRIBE TEMPLATES` (§10.6) over the memory's metadata table
+  (OMS §28.4.1), including the replication rules of §8.18.1, the
+  define-time body validation of §8.18.2, and error codes CAL-E130--E137.
+  An implementation MAY support templates without saved queries; both are
+  read surfaces at Tier 0 once defined.
 
 A Tier-0/1 implementation is not diminished by declining both modules --
 **tiers gate operations, not portability** (§2.2), and conformance claims
@@ -3287,6 +3504,32 @@ All error codes use the `CAL-E` prefix.
 | CAL-E126 | ReasonRequired — a required `BECAUSE` reason is missing or empty at execution |
 | CAL-E127 | MappingUnknown — `REHYDRATE` named a mapping id that resolves to neither a live session mapping nor a vault entry |
 
+### Saved Query Errors (CAL-E130 -- CAL-E137, new in 1.3)
+
+> **Why this block is not CAL-E053--E059.** Those codes sit in the free gap
+> between the Evolve block (ends E052) and the grain-type block (starts E060),
+> and are the natural home for a new family. They are not used here because the
+> reference implementation had already assigned CAL-E040--E059 to its template
+> and saved-query errors before this section existed, overlapping the Evolve
+> codes this registry published in 1.5 -- only CAL-E044 (`Tier1NotEnabled`)
+> agrees between the two. Codes are append-only in every registry, so neither
+> side can renumber, and putting the saved-query family at E053--E059 would
+> place it directly against the half of that implementation's block that is
+> *already* colliding. A fresh block collides with nothing, and the divergence
+> below is a defect to reconcile in the implementation rather than a
+> disagreement to encode in the registry.
+
+| Code | Description |
+|------|-------------|
+| CAL-E130 | QueryNotFound — `RUN` or `DROP QUERY` named a definition that does not exist |
+| CAL-E131 | TooManyQueries — the namespace already holds the maximum number of saved queries (§8.18.2) |
+| CAL-E132 | QueryBodyTooLarge — body exceeds the maximum body size (§8.18.2) |
+| CAL-E133 | TooManyQueryParams — more declared parameters than the maximum (§8.18.2) |
+| CAL-E134 | MissingQueryParam — a parameter with no default received no argument at the `RUN` call site |
+| CAL-E135 | RecursiveQuery — `RUN` appears inside a `DEFINE QUERY` body (§8.18.2 rule 2) |
+| CAL-E136 | QueryBodyNotReadOnly — a body contains a statement above Tier 0 (§8.18.2 rule 1) |
+| CAL-E137 | InvalidQueryBody — the body failed to parse at definition time with its parameters standing in (§8.18.2 rule 3) |
+
 ### Shortcut and Grain Type Errors (CAL-E060 -- CAL-E066)
 
 | Code | Description |
@@ -3379,7 +3622,7 @@ ADD, SUPERSEDE, REVERT, SET, REASON, BECAUSE, REHYDRATE,
 FORGET, PURGE, SUBJECT, OLDER, THAN, TYPE,
 GRANT, REVOKE, ON, TO, SHOW, GRANTS, PRINCIPAL,
 APPROVE, REJECT, APPLY, ROLLBACK, RUN, LOOP, FULL,
-STREAM, TEMPLATE, DEFINE, UNDEFINE, EXTENDS,
+STREAM, TEMPLATE, DEFINE, UNDEFINE, EXTENDS, DROP, QUERY, QUERIES, DESCRIPTION,
 HEADER, ELEMENT, ELEMENT_SUMMARY, ELEMENT_OMIT, SOURCE_BREAK, FOOTER,
 PREFERENCE, KNOWLEDGE, PERMISSION, INTERACTION, AGENCY, LIFECYCLE, OBSERVATION,
 CAL, OF
@@ -3496,7 +3739,7 @@ ROLE                                        -- DEFINE ROLE, deferred (§3.2)
 
 | Version | Date | Change |
 |---------|------|--------|
-| 1.3-draft | 2026-08-10 | **The pillar changes, on purpose and in the open.** 1.0--1.2 promised "non-destructive by grammar; no unsafe mode." The promise was true and had a hidden cost: real deployments still needed erasure -- GDPR, retention -- so destruction happened anyway, outside the language, ungoverned by any spec. Exiling destruction never prevented it; it only prevented *specifying* it. 1.3 brings it inside, where grammar bounds its shape (whole grains by hash, identity, or age -- never a predicate, never a key, no history rewrite, no `UNFORGET`), grants gate it per principal, and the audit trail sees it (a mandatory in-memory audit Observation per Tier-2 execution). Adds the four-tier model (Core/Evolve/Destroy/Control; tiers gate operations, not portability -- §2.2), Tier 2 statements `FORGET <hash>`/`FORGET SUBJECT`/`PURGE OLDER THAN` (§8.14), Tier 3 DCL `GRANT`/`REVOKE`/`SHOW GRANTS`/`DESCRIBE PRINCIPAL` over in-memory grant grains (§8.15, OMS §12.6), Tier 3 governance statements `APPROVE`/`REJECT`/`APPLY`/`ROLLBACK`/`RUN LOOP` + `DESCRIBE loop`-family (§8.16), principal-bound sessions and the credential/policy split (§18.4), authorization error codes CAL-E121--E126, and the `cal_tiers` conformance declaration. `DEFINE ROLE` reserved, deferred. The anonymization batch (2026-08-16) adds `WITH anonymize("<level>")` as a strengthen-only recall/per-source option (§8.1.2, §8.2.1), the Tier-3 `REHYDRATE` statement with its stated classification obligation (§8.17, CAL-E127), pairing OMS §10.5's pseudonymized-egress model. Every 1.0--1.2 document remains valid Tier-0/1 CAL; a session without grants is exactly the language those releases promised -- the floor, not the ceiling. |
+| 1.3-draft | 2026-08-10 | **The pillar changes, on purpose and in the open.** 1.0--1.2 promised "non-destructive by grammar; no unsafe mode." The promise was true and had a hidden cost: real deployments still needed erasure -- GDPR, retention -- so destruction happened anyway, outside the language, ungoverned by any spec. Exiling destruction never prevented it; it only prevented *specifying* it. 1.3 brings it inside, where grammar bounds its shape (whole grains by hash, identity, or age -- never a predicate, never a key, no history rewrite, no `UNFORGET`), grants gate it per principal, and the audit trail sees it (a mandatory in-memory audit Observation per Tier-2 execution). Adds the four-tier model (Core/Evolve/Destroy/Control; tiers gate operations, not portability -- §2.2), Tier 2 statements `FORGET <hash>`/`FORGET SUBJECT`/`PURGE OLDER THAN` (§8.14), Tier 3 DCL `GRANT`/`REVOKE`/`SHOW GRANTS`/`DESCRIBE PRINCIPAL` over in-memory grant grains (§8.15, OMS §12.6), Tier 3 governance statements `APPROVE`/`REJECT`/`APPLY`/`ROLLBACK`/`RUN LOOP` + `DESCRIBE loop`-family (§8.16), principal-bound sessions and the credential/policy split (§18.4), authorization error codes CAL-E121--E126, and the `cal_tiers` conformance declaration. `DEFINE ROLE` reserved, deferred. The anonymization batch (2026-08-16) adds `WITH anonymize("<level>")` as a strengthen-only recall/per-source option (§8.1.2, §8.2.1), the Tier-3 `REHYDRATE` statement with its stated classification obligation (§8.17, CAL-E127), pairing OMS §10.5's pseudonymized-egress model. The trigger batch (2026-08-19) adds `RECALL triggers` and removes the `ON "..."` workflow clause with OMS's `Workflow.trigger`. The saved-query batch (2026-08-19) adds §8.18 saved queries -- `DEFINE QUERY`/`RUN`/`DROP QUERY`/`DESCRIBE QUERIES`, Tier-0-only bodies validated at definition time, definitions as host metadata (OMS §28.4.1) rather than grains, error codes CAL-E130--E137 -- and admits `DROP` to the grammar with a closed two-target set that reaches no grain (§2.4). Every 1.0--1.2 document remains valid Tier-0/1 CAL; a session without grants is exactly the language those releases promised -- the floor, not the ceiling. |
 | 1.2 | 2026-08-03 | As part of the OMS v1.5 release, adds the **Recommendation** grain type (`0x0C`) to the closed query set: `RECALL recommendations` with a type-specific field set (`target_ref`, `analyzer`, `severity`, `dedup_key`, `rec_status`), `<recommendation>` content projection, TOON columns, `recommendation_field` grammar production, and the type in `grain_type_plural`/`grain_type_singular`, `DESCRIBE`, and the JSON `valid_values` enum. Recommendation is **query-only** — it is engine-emitted and lifecycle-gated, so it is deliberately absent from the CAL-addable set (`ADD`/`SUPERSEDE SET` never create or transition a recommendation). Also adds the **`ELEMENT` shorthand** for custom templates (Section 10.6.1): `DEFINE TEMPLATE <name> AS "<text>"` and `FORMAT TEMPLATE "<text>"`, both defined by equivalence to an `ELEMENT` section, plus the `template_shorthand` production and `"TEMPLATE" , string_literal` in `format_spec`. This also corrects two 1.1 defects in the same examples (Sections 10.1.1, 14.2.1, 27): the `TEMPLATE "..."` form they use was not admitted by the Section 4 grammar, and they interpolated bare `{{subject}}`/`{{object}}` rather than the `grain.` namespace that Section 10.5 defines and Section 10.8 closes. Backward-compatible. |
 | 1.1 | 2026-03-05 | Multi-format output: FORMAT and AS clauses accept bracketed format lists (`FORMAT [markdown, json]`). Single query execution produces multiple renderings. New Section 10.1.1 (syntax and rules), Section 14.2.1 (multi-format response shape), error code CAL-E110. Backward-compatible — single-format syntax unchanged. As part of the OMS v1.4 release, also adds the Skill grain type (`0x0B`) to the closed query set (`RECALL skills` / `ADD skill`, type-specific field set, `<skill>` projection, TOON columns, `mg:capable_of` in the `AGENCY` shortcut) and corrects `belief`/`action` literals the rename left behind (`grain_type_plural`, `RECALL MY`, TOON tables, `DESCRIBE` listing, `CAL-E051`). |
 | 1.0 | 2026-03-03 | Initial CAL specification. 12-variant statement model. Tier 0 (RECALL, ASSEMBLE, SetOp, EXISTS, HISTORY, EXPLAIN, DESCRIBE, BATCH, COALESCE) + Tier 1 (ADD, SUPERSEDE, REVERT). ASSEMBLE with budget, priority, format, streaming. Semantic shortcuts (ABOUT, RECENT, SINCE, LIKE, MY, CONTRADICTIONS, BETWEEN). LET bindings. Custom FORMAT templates (Mustache-subset). Grain-type-specific queryable fields for all 10 OMS types. mg: relation vocabulary with category shortcuts. Domain profile querying. Dual wire format (text/cal + application/json+cal). Internationalization (Unicode NFC, cross-lingual search, bidi safety). Streaming protocol (SSE, NDJSON, WebSocket). THREAD shorthand. HISTORY AS OF and DIFF. Non-destructive safety model. Content Projection Model with flat semantic output (Section 10.3-10.4). PROJECT clause for custom field surfacing. Per-grain-type content projection rules with humanize() and time humanization. ELEMENT/ELEMENT_SUMMARY/SOURCE_BREAK template sections for flat semantic rendering. TOON (Token-Oriented Object Notation) format support — `toon` as a first-class FORMAT/AS preset (Section 10.9): tabular CSV rendering for uniform RECALL results, grouped-section rendering for ASSEMBLE results, per-grain-type column sets at each disclosure level, PROJECT integration, STREAM compatibility, auto-TOON budget-pressure hint (CAL-W005). |

--- a/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
+++ b/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
@@ -321,7 +321,8 @@ statement       = explain_stmt | recall_stmt | assemble_stmt | set_stmt
                 | forget_stmt | purge_stmt                        (* Tier 2 *)
                 | grant_stmt | revoke_stmt | show_grants_stmt     (* Tier 3 *)
                 | approve_stmt | reject_stmt | apply_stmt
-                | rollback_stmt | run_loop_stmt ;                 (* Tier 3 *)
+                | rollback_stmt | run_loop_stmt
+                | rehydrate_stmt ;                                (* Tier 3 *)
 
 (* --- Tier 0: Read --- *)
 
@@ -486,11 +487,13 @@ with_option     = "superseded" | "score_breakdown" | "explanation" | "provenance
                 | "dedup" , "(" , field_name , ")"
                 | "locale" , "(" , string_literal , ")"
                 | "cache" , "(" , "ttl" , "=" , positive_integer , ")"
+                | "anonymize" , "(" , anonymize_level , ")"
                 | extension_option ;
 diversity_spec  = "mmr" , [ "," , "lambda" , "=" , number ]
                 | "threshold" , "," , number ;
 consistency_level = "eventual" | "bounded" , "(" , number , ")" | "linearizable" ;
 disclosure_level = "summary" | "headlines" | "full" ;
+anonymize_level = "standard" | "strict" ;
 extension_option = "x_" , identifier , [ "(" , value_list , ")" ] ;
 
 pipeline        = { pipe_stage } ;
@@ -547,6 +550,8 @@ grant_stmt      = "GRANT" , verb_list , "ON" , ns_scope , "TO" , principal ,
 revoke_stmt     = "REVOKE" , verb_list , "ON" , ns_scope , "FROM" , principal ,
                   [ with_clause ] ;
 show_grants_stmt = "SHOW" , "GRANTS" , [ "FOR" , principal ] ;
+rehydrate_stmt  = "REHYDRATE" , string_literal ,
+                  "WITH" , "mapping" , "(" , string_literal , ")" ;
 verb_list       = verb , { "," , verb } ;
 verb            = "read" | "write" | "supersede" | "delete" | "erase"
                 | "loop.run" | "loop.review" | "loop.apply" | "admin" ;
@@ -992,6 +997,30 @@ RECALL events THREAD "sess-123"
 RECALL events THREAD FROM sha256:a1b2c3d4...
 ```
 
+#### 8.1.2 WITH anonymize (new in 1.3)
+
+```sql
+RECALL facts WHERE subject = "caller:john" WITH anonymize("strict")
+```
+
+Requests pseudonymized results for this one query. **Strengthen-only**: the
+option MAY raise the treatment an active egress policy (OMS Section 10.5)
+would apply -- `"standard"` asserts the declared policy (a no-op where one
+is active), `"strict"` treats every category at redaction severity -- and
+MUST NOT weaken or disable a file-declared policy. Two reasons the
+weakening form does not exist, both load-bearing:
+
+1. Unknown WITH options warn-and-skip (Section 25 forward compatibility),
+   so on an older implementation this option silently does nothing. That is
+   survivable only because it was never the gate -- the file-declared
+   policy is.
+2. A weakening spelling would make every query author a policy author. The
+   file's declaration MUST outrank query text, or the policy is advisory.
+
+Implementations without anonymization support treat the option as unknown
+(warn-and-skip); consumers MUST NOT read the absence of the response's
+`anonymized` report as "values are safe".
+
 ### 8.2 ASSEMBLE (Tier 0)
 
 The flagship new statement. Composes a context block from multiple RECALL sources with token budgets, priority ordering, format control, and progressive disclosure.
@@ -1040,6 +1069,22 @@ Token estimation is approximate by design. The response MUST report actual token
 | Max context_name length | 64 characters |
 | Max FOR string length | 256 characters |
 | ASSEMBLE timeout | 10,000ms |
+
+#### 8.2.1 Per-source anonymize override (new in 1.3)
+
+A named source MAY carry its own `WITH anonymize(...)`, same strengthen-only
+rule as Section 8.1.2: a mounted source's own file policy applies first, and
+the override can only add severity on top. This is the multi-file case where
+per-source treatment genuinely differs -- a mounted org replica may warrant
+stricter handling than the session's own memory.
+
+```sql
+ASSEMBLE briefing FOR "customer call prep"
+  FROM
+    work:       (RECALL facts ABOUT "caller:john" LIMIT 20) WITH anonymize("strict"),
+    background: (RECALL org.facts ABOUT "acme" LIMIT 10)
+  BUDGET 1500 tokens
+```
 
 ### 8.3 EXISTS (Tier 0)
 
@@ -1434,6 +1479,36 @@ DESCRIBE policy      -- the effective host policy (read)
 - Governance statements are refused inside `BATCH`, saved-query bodies, and
   `proposal_cal` (§8.14.3) -- no one-round-trip approve-and-apply macro, and
   no recommendation whose payload approves other recommendations.
+
+### 8.17 REHYDRATE (Tier 3 -- new in 1.3)
+
+```sql
+REHYDRATE "Hi [PERSON_1], I've verified pin [PIN_1]." WITH mapping("a1b2c3d4e5f60718")
+```
+
+The return leg of the pseudonymization round trip (OMS Section 10.5):
+replaces exact placeholder tokens in the text with their originals from the
+mapping the id names. Unmatched tokens are left intact and reported, never
+guessed.
+
+**Classification: Control -- stated rather than hidden, because rehydration
+is re-identification.** The statement MUST NOT classify as a plain read: an
+implementation with authorization MUST gate it on the `admin` verb (or an
+equivalent dedicated grant) and MUST write a Tier-2 audit Observation per
+execution carrying the revealed values' *fingerprints*, never the
+identities -- the same non-re-identifying audit rule bulk erasure follows
+(Section 21). An implementation whose statement classification is
+exhaustive-without-wildcard is forced to decide this at build time, which
+is the point.
+
+**Resolution.** The mapping id resolves against the session's live mappings
+first, then the file's sealed vault (OMS Section 10.5.2). An id whose
+mapping no longer exists is an error (CAL-E127), not an empty substitution
+-- silently returning the placeholders would be indistinguishable from a
+model echoing them.
+
+Refused inside `BATCH`, saved-query bodies, and `proposal_cal`, like every
+Tier 2/3 statement (Section 8.14.3).
 
 ---
 
@@ -2883,7 +2958,7 @@ Everything in Core, plus:
 - `LET` bindings
 - All semantic shortcuts (SINCE, LIKE, MY, CONTRADICTIONS, BETWEEN)
 - `ASSEMBLE` statement with BUDGET, PRIORITY, FORMAT
-- Advanced `WITH` options (diversity, score_breakdown, explanation, provenance, progressive_disclosure)
+- Advanced `WITH` options (diversity, score_breakdown, explanation, provenance, progressive_disclosure, anonymize)
 - `AS` per-query format control
 - `application/json+cal` wire format (dual wire format)
 - Error suggestion system ("did you mean?")
@@ -3076,6 +3151,9 @@ It can read, assemble, and evolve memories, but never delete them.
 - REASON is mandatory for all evolve operations; BECAUSE is mandatory for
   governance and bulk-erasure statements.
 - Use HISTORY to check current version before SUPERSEDE.
+- WITH anonymize("standard"|"strict") can only STRENGTHEN a file-declared
+  pseudonymization policy, never weaken one; REHYDRATE (reverse lookup)
+  is grant-gated and audited like destruction.
 ```
 
 ---
@@ -3183,6 +3261,7 @@ All error codes use the `CAL-E` prefix.
 | CAL-E124 | SelfApproval — the reviewing principal created, or triggered the run that authored, this recommendation |
 | CAL-E125 | ContextRefused — Tier 2/3 statement inside `BATCH`, a saved-query body, or `proposal_cal` where forbidden (§8.14.3) |
 | CAL-E126 | ReasonRequired — a required `BECAUSE` reason is missing or empty at execution |
+| CAL-E127 | MappingUnknown — `REHYDRATE` named a mapping id that resolves to neither a live session mapping nor a vault entry |
 
 ### Shortcut and Grain Type Errors (CAL-E060 -- CAL-E066)
 
@@ -3272,7 +3351,7 @@ EXISTS, HISTORY, DESCRIBE, BATCH, COALESCE,
 ABOUT, RECENT, SINCE, LIKE, MY, CONTRADICTIONS, AS,
 FOR, FROM, BUDGET, PRIORITY, FORMAT,
 LET, THREAD, DIFF,
-ADD, SUPERSEDE, REVERT, SET, REASON, BECAUSE,
+ADD, SUPERSEDE, REVERT, SET, REASON, BECAUSE, REHYDRATE,
 FORGET, PURGE, SUBJECT, OLDER, THAN, TYPE,
 GRANT, REVOKE, ON, TO, SHOW, GRANTS, PRINCIPAL,
 APPROVE, REJECT, APPLY, ROLLBACK, RUN, LOOP, FULL,
@@ -3393,7 +3472,7 @@ ROLE                                        -- DEFINE ROLE, deferred (§3.2)
 
 | Version | Date | Change |
 |---------|------|--------|
-| 1.3-draft | 2026-08-10 | **The pillar changes, on purpose and in the open.** 1.0--1.2 promised "non-destructive by grammar; no unsafe mode." The promise was true and had a hidden cost: real deployments still needed erasure -- GDPR, retention -- so destruction happened anyway, outside the language, ungoverned by any spec. Exiling destruction never prevented it; it only prevented *specifying* it. 1.3 brings it inside, where grammar bounds its shape (whole grains by hash, identity, or age -- never a predicate, never a key, no history rewrite, no `UNFORGET`), grants gate it per principal, and the audit trail sees it (a mandatory in-memory audit Observation per Tier-2 execution). Adds the four-tier model (Core/Evolve/Destroy/Control; tiers gate operations, not portability -- §2.2), Tier 2 statements `FORGET <hash>`/`FORGET SUBJECT`/`PURGE OLDER THAN` (§8.14), Tier 3 DCL `GRANT`/`REVOKE`/`SHOW GRANTS`/`DESCRIBE PRINCIPAL` over in-memory grant grains (§8.15, OMS §12.6), Tier 3 governance statements `APPROVE`/`REJECT`/`APPLY`/`ROLLBACK`/`RUN LOOP` + `DESCRIBE loop`-family (§8.16), principal-bound sessions and the credential/policy split (§18.4), authorization error codes CAL-E121--E126, and the `cal_tiers` conformance declaration. `DEFINE ROLE` reserved, deferred. Every 1.0--1.2 document remains valid Tier-0/1 CAL; a session without grants is exactly the language those releases promised -- the floor, not the ceiling. |
+| 1.3-draft | 2026-08-10 | **The pillar changes, on purpose and in the open.** 1.0--1.2 promised "non-destructive by grammar; no unsafe mode." The promise was true and had a hidden cost: real deployments still needed erasure -- GDPR, retention -- so destruction happened anyway, outside the language, ungoverned by any spec. Exiling destruction never prevented it; it only prevented *specifying* it. 1.3 brings it inside, where grammar bounds its shape (whole grains by hash, identity, or age -- never a predicate, never a key, no history rewrite, no `UNFORGET`), grants gate it per principal, and the audit trail sees it (a mandatory in-memory audit Observation per Tier-2 execution). Adds the four-tier model (Core/Evolve/Destroy/Control; tiers gate operations, not portability -- §2.2), Tier 2 statements `FORGET <hash>`/`FORGET SUBJECT`/`PURGE OLDER THAN` (§8.14), Tier 3 DCL `GRANT`/`REVOKE`/`SHOW GRANTS`/`DESCRIBE PRINCIPAL` over in-memory grant grains (§8.15, OMS §12.6), Tier 3 governance statements `APPROVE`/`REJECT`/`APPLY`/`ROLLBACK`/`RUN LOOP` + `DESCRIBE loop`-family (§8.16), principal-bound sessions and the credential/policy split (§18.4), authorization error codes CAL-E121--E126, and the `cal_tiers` conformance declaration. `DEFINE ROLE` reserved, deferred. The anonymization batch (2026-08-16) adds `WITH anonymize("<level>")` as a strengthen-only recall/per-source option (§8.1.2, §8.2.1), the Tier-3 `REHYDRATE` statement with its stated classification obligation (§8.17, CAL-E127), pairing OMS §10.5's pseudonymized-egress model. Every 1.0--1.2 document remains valid Tier-0/1 CAL; a session without grants is exactly the language those releases promised -- the floor, not the ceiling. |
 | 1.2 | 2026-08-03 | As part of the OMS v1.5 release, adds the **Recommendation** grain type (`0x0C`) to the closed query set: `RECALL recommendations` with a type-specific field set (`target_ref`, `analyzer`, `severity`, `dedup_key`, `rec_status`), `<recommendation>` content projection, TOON columns, `recommendation_field` grammar production, and the type in `grain_type_plural`/`grain_type_singular`, `DESCRIBE`, and the JSON `valid_values` enum. Recommendation is **query-only** — it is engine-emitted and lifecycle-gated, so it is deliberately absent from the CAL-addable set (`ADD`/`SUPERSEDE SET` never create or transition a recommendation). Also adds the **`ELEMENT` shorthand** for custom templates (Section 10.6.1): `DEFINE TEMPLATE <name> AS "<text>"` and `FORMAT TEMPLATE "<text>"`, both defined by equivalence to an `ELEMENT` section, plus the `template_shorthand` production and `"TEMPLATE" , string_literal` in `format_spec`. This also corrects two 1.1 defects in the same examples (Sections 10.1.1, 14.2.1, 27): the `TEMPLATE "..."` form they use was not admitted by the Section 4 grammar, and they interpolated bare `{{subject}}`/`{{object}}` rather than the `grain.` namespace that Section 10.5 defines and Section 10.8 closes. Backward-compatible. |
 | 1.1 | 2026-03-05 | Multi-format output: FORMAT and AS clauses accept bracketed format lists (`FORMAT [markdown, json]`). Single query execution produces multiple renderings. New Section 10.1.1 (syntax and rules), Section 14.2.1 (multi-format response shape), error code CAL-E110. Backward-compatible — single-format syntax unchanged. As part of the OMS v1.4 release, also adds the Skill grain type (`0x0B`) to the closed query set (`RECALL skills` / `ADD skill`, type-specific field set, `<skill>` projection, TOON columns, `mg:capable_of` in the `AGENCY` shortcut) and corrects `belief`/`action` literals the rename left behind (`grain_type_plural`, `RECALL MY`, TOON tables, `DESCRIBE` listing, `CAL-E051`). |
 | 1.0 | 2026-03-03 | Initial CAL specification. 12-variant statement model. Tier 0 (RECALL, ASSEMBLE, SetOp, EXISTS, HISTORY, EXPLAIN, DESCRIBE, BATCH, COALESCE) + Tier 1 (ADD, SUPERSEDE, REVERT). ASSEMBLE with budget, priority, format, streaming. Semantic shortcuts (ABOUT, RECENT, SINCE, LIKE, MY, CONTRADICTIONS, BETWEEN). LET bindings. Custom FORMAT templates (Mustache-subset). Grain-type-specific queryable fields for all 10 OMS types. mg: relation vocabulary with category shortcuts. Domain profile querying. Dual wire format (text/cal + application/json+cal). Internationalization (Unicode NFC, cross-lingual search, bidi safety). Streaming protocol (SSE, NDJSON, WebSocket). THREAD shorthand. HISTORY AS OF and DIFF. Non-destructive safety model. Content Projection Model with flat semantic output (Section 10.3-10.4). PROJECT clause for custom field surfacing. Per-grain-type content projection rules with humanize() and time humanization. ELEMENT/ELEMENT_SUMMARY/SOURCE_BREAK template sections for flat semantic rendering. TOON (Token-Oriented Object Notation) format support — `toon` as a first-class FORMAT/AS preset (Section 10.9): tabular CSV rendering for uniform RECALL results, grouped-section rendering for ASSEMBLE results, per-grain-type column sets at each disclosure level, PROJECT integration, STREAM compatibility, auto-TOON budget-pressure hint (CAL-W005). |

--- a/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
+++ b/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
@@ -1618,6 +1618,14 @@ definition *is*, and an incoming update MUST leave the local stamp intact. This
 is the same split §27.8 draws for triggers and §8.12 draws for governance
 state: **what a definition is replicates; where one host got to does not.**
 
+**Identity.** A saved query carries the two stamps OMS §28.4.1 requires of any
+stored definition: `updated_at` (the replication tiebreaker) and
+`definition_hash` (the SHA-256 identity of this revision's body). Both are
+reported by `DESCRIBE QUERIES` (§8.18.4). This is what makes
+`query:<namespace>/<name>` a pinnable Recommendation target (OMS §8.12) — a
+governed change to a saved query can name the revision it replaced and store an
+inverse that reinstates exactly that one.
+
 A point-in-time restore reconstructs grain history and MUST skip the
 definition registry -- a restore to last Tuesday is a statement about memory,
 not an instruction to revert an operator's query edits -- and MUST report that
@@ -1728,8 +1736,9 @@ and it is lossless against memory (§2.4). Dropping an absent name is
 `CAL-E130`.
 
 `DESCRIBE QUERIES` is Tier 0 and lists the registered definitions -- name,
-description, parameter count, body size, revision stamp, and last-execution
-stamp where the host keeps one. It is the discovery surface an agent uses to
+description, parameter count, body size, both revision stamps (`updated_at` and
+`definition_hash`, §8.18.1), and the last-execution stamp where the host keeps
+one. It is the discovery surface an agent uses to
 find what it may `RUN`.
 
 `DESCRIBE capabilities` SHOULD report saved-query support and the limits of
@@ -2153,6 +2162,61 @@ definition MUST NOT combine the two forms.
 </context>
 ```
 
+### 10.6.3 Template identity, revision, and DROP TEMPLATE (new in 1.3)
+
+A registered template is a **stored definition** and lives in the memory's
+metadata table under `tpl:<name>` (OMS §28.4.1), on exactly the terms §8.18.1
+sets out for saved queries: carried by the memory rather than the client, not a
+grain, replicating latest-wins, with usage stamps that do not replicate.
+
+**Identity.** A template's identity is `<namespace>/<name>` — the form OMS
+§8.12 already uses as a Recommendation `target_ref`. Versions 1.0–1.2 gave a
+template a bare 64-character name and nothing else, which left that target
+unpinnable: a Recommendation applied against `template:acct/invoice_row` could
+not say which revision it changed, and so could not store an honest inverse.
+
+Every stored template therefore carries the two stamps OMS §28.4.1 requires of
+any definition — `updated_at` (the replication tiebreaker) and
+`definition_hash` (the SHA-256 identity of this revision's body). A host MUST
+report both from `DESCRIBE TEMPLATES`, so a reviewer can see which revision a
+proposal targets and an auditor can tell whether the template that rendered a
+`summary` is still the template that would render it now.
+
+The revision covers the template's **own** body, not its parent's. A template
+that `EXTENDS` a preset resolves against whatever that preset is at render
+time; presets are implementation-shipped and versioned with the
+implementation, so they are not stored definitions and have no
+`definition_hash`.
+
+**Built-ins are not stored definitions.** The presets and built-in templates an
+implementation ships are code, not metadata. They MUST NOT be droppable, MUST
+NOT be overwritten by `DEFINE TEMPLATE`, and MUST NOT be persisted into the
+metadata table — a memory that carried a copy of a built-in would pin one
+implementation's rendering of it forever.
+
+**DROP TEMPLATE.**
+
+```sql
+DROP TEMPLATE "invoice_row"
+DESCRIBE TEMPLATES
+```
+
+`DROP TEMPLATE` removes a stored template definition. It is Tier 3 (`admin`),
+it touches no grain, and it is lossless against memory (§2.4): the grains the
+template ever rendered are untouched, and re-running the `DEFINE` restores it
+byte-for-byte. Dropping a name that does not exist, or a built-in, is an error;
+dropping a template another template `EXTENDS` MUST be refused rather than
+leaving a dangling parent.
+
+Nothing here is retroactive. Output already rendered through a dropped or
+replaced template is text that was already produced; a template is a rendering
+instruction (§10.8), so changing one changes what renders *next*.
+
+`UNDEFINE` remains reserved and unspecified (§2.4, Appendix D). It was the
+placeholder for these semantics, `DROP TEMPLATE` is the spelling that shipped,
+and an implementation MUST NOT accept `UNDEFINE` as an alias for it.
+
+
 ### 10.7 Template Inheritance
 
 Templates inherit from presets via `EXTENDS`. Sections not defined in the template use the parent preset's definition. Inheritance depth is limited to 1 (template -> preset only). Default parent is `readable`.
@@ -2182,6 +2246,7 @@ Templates are rendering instructions, not programs:
 | Template name length | 64 characters |
 | Inheritance depth | 1 |
 | Variable set | Closed |
+| Revision stamps | `updated_at` + `definition_hash` (§10.6.3, OMS §28.4.1) |
 
 ### 10.9 TOON — Token-Oriented Object Notation
 

--- a/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
+++ b/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
@@ -196,7 +196,7 @@ If these appear in a query, they are parse errors, not recognized keywords. This
 
 **Changed in 1.3:** `FORGET` and `PURGE` moved from this list to the Tier 2 keyword set, and `GRANT`/`REVOKE` to the Tier 3 keyword set (§3.2). The block on them existed to force a specification-level decision before any destructive or control surface entered the language -- this revision is that decision, and the statements it admits are bounded by §2.1--§2.3.
 
-Note: Tier 1/2/3 keywords are always **parsed** (so `EXPLAIN FORGET ...` works as a dry-run even where execution is unavailable). The **executor** rejects non-EXPLAIN statements above the session's effective tier: `CAL-E044: Tier1NotEnabled` for Tier 1, `CAL-E120`/`CAL-E121` for Tier 2/3 (§22). This two-layer approach ensures `EXPLAIN` can always preview an operation without risk.
+Note: Tier 1/2/3 keywords are always **parsed** (so `EXPLAIN FORGET ...` works as a dry-run even where execution is unavailable). The **executor** rejects non-EXPLAIN statements above the session's effective tier: `CAL-E044: Tier1NotEnabled` for Tier 1, `CAL-E121`/`CAL-E122` for Tier 2/3 (§22). This two-layer approach ensures `EXPLAIN` can always preview an operation without risk.
 
 ---
 
@@ -1321,7 +1321,7 @@ Tier-2 statements execute only when the session principal (§18.4) holds the
 required verb for the target namespace, resolved from the memory's own grant
 grains (OMS §12.6) or, on a Tier-2-without-Tier-3 host, from the host's
 authorization model. Enforcement is fail-closed: no principal, no grants, or
-no authorization model at all → `CAL-E120`/`CAL-E121`, nothing executes.
+no authorization model at all → `CAL-E121`/`CAL-E122`, nothing executes.
 A host session designated *owner* (OMS §12.6.4) is exempt from grant lookup.
 
 #### 8.14.3 Context restrictions
@@ -2641,7 +2641,7 @@ in the session executes *as* that principal.
 - **Fail-closed.** An unauthenticated or unknown caller where a credential
   map is configured resolves to an anonymous principal with at most `read`;
   where no authorization model exists at all, Tier 2/3 statements MUST be
-  refused (`CAL-E120`).
+  refused (`CAL-E122`).
 
 ---
 
@@ -2814,7 +2814,7 @@ See [Appendix C](#appendix-c-error-code-registry) for the complete registry. Err
 | CAL-E085 -- CAL-E096 | Template | 12 |
 | CAL-E100 | Version | 1 |
 | CAL-E110, CAL-E113 | Multi-Format | 2 |
-| CAL-E120 -- CAL-E125 | Authorization (Tier 2/3, new in 1.3) | 6 |
+| CAL-E121 -- CAL-E126 | Authorization (Tier 2/3, new in 1.3) | 6 |
 
 ### 22.3 Warning Codes
 
@@ -2921,7 +2921,7 @@ Orthogonal to Levels 1--4, the Tier 2/3 statement families are optional
 
 - **Destroy (Tier 2):** `FORGET <hash>`, `FORGET SUBJECT`, `PURGE OLDER
   THAN`; an authorization model (host-defined suffices); the audit
-  Observation (§8.14.4); error codes CAL-E120--E125. Tier 2 without Tier 3
+  Observation (§8.14.4); error codes CAL-E121--E126. Tier 2 without Tier 3
   is legal.
 - **Control (Tier 3):** `GRANT`/`REVOKE`/`SHOW GRANTS`/`DESCRIBE PRINCIPAL`
   over in-memory grant grains (OMS §12.6); principal-bound sessions
@@ -3070,7 +3070,7 @@ It can read, assemble, and evolve memories, but never delete them.
 - CAL cannot rewrite history. Assume you cannot delete, erase, forget, or
   destroy data: destruction and GRANT/APPROVE-class statements execute only
   for sessions explicitly granted them -- check DESCRIBE capabilities before
-  attempting any, and expect CAL-E120/E121 refusals otherwise.
+  attempting any, and expect CAL-E121/E122 refusals otherwise.
 - REASON is mandatory for all evolve operations; BECAUSE is mandatory for
   governance and bulk-erasure statements.
 - Use HISTORY to check current version before SUPERSEDE.
@@ -3166,16 +3166,21 @@ All error codes use the `CAL-E` prefix.
 | CAL-E110 | Too many formats in multi-format list (maximum 5) |
 | CAL-E113 | Duplicate format key in multi-format list (alias or canonical name collision) |
 
-### Authorization Errors (CAL-E120 -- CAL-E125, new in 1.3)
+### Authorization Errors (CAL-E121 -- CAL-E126, new in 1.3)
+
+> The block begins at E121, not E120: the deployed dialect's registry had
+> already assigned CAL-E120 (JSON+CAL parse failure) before this draft, and
+> codes are append-only in every registry. E121 matches its shipped
+> `NotAuthorized` exactly.
 
 | Code | Description |
 |------|-------------|
-| CAL-E120 | TierNotSupported — the host does not implement this statement's tier (or has no authorization model for Tier 2/3) |
 | CAL-E121 | NotAuthorized — the session principal lacks the statement's verb on the target namespace. The message SHOULD name the missing verb, the resource, and the `GRANT` statement that would confer it |
-| CAL-E122 | UnknownPrincipal — the named or session principal does not resolve |
-| CAL-E123 | SelfApproval — the reviewing principal created, or triggered the run that authored, this recommendation |
-| CAL-E124 | ContextRefused — Tier 2/3 statement inside `BATCH`, a saved-query body, or `proposal_cal` where forbidden (§8.14.3) |
-| CAL-E125 | ReasonRequired — a required `BECAUSE` reason is missing or empty at execution |
+| CAL-E122 | TierNotSupported — the host does not implement this statement's tier (or has no authorization model for Tier 2/3) |
+| CAL-E123 | UnknownPrincipal — the named or session principal does not resolve |
+| CAL-E124 | SelfApproval — the reviewing principal created, or triggered the run that authored, this recommendation |
+| CAL-E125 | ContextRefused — Tier 2/3 statement inside `BATCH`, a saved-query body, or `proposal_cal` where forbidden (§8.14.3) |
+| CAL-E126 | ReasonRequired — a required `BECAUSE` reason is missing or empty at execution |
 
 ### Shortcut and Grain Type Errors (CAL-E060 -- CAL-E066)
 
@@ -3386,7 +3391,7 @@ ROLE                                        -- DEFINE ROLE, deferred (§3.2)
 
 | Version | Date | Change |
 |---------|------|--------|
-| 1.3-draft | 2026-08-10 | **The pillar changes, on purpose and in the open.** 1.0--1.2 promised "non-destructive by grammar; no unsafe mode." The promise was true and had a hidden cost: real deployments still needed erasure -- GDPR, retention -- so destruction happened anyway, outside the language, ungoverned by any spec. Exiling destruction never prevented it; it only prevented *specifying* it. 1.3 brings it inside, where grammar bounds its shape (whole grains by hash, identity, or age -- never a predicate, never a key, no history rewrite, no `UNFORGET`), grants gate it per principal, and the audit trail sees it (a mandatory in-memory audit Observation per Tier-2 execution). Adds the four-tier model (Core/Evolve/Destroy/Control; tiers gate operations, not portability -- §2.2), Tier 2 statements `FORGET <hash>`/`FORGET SUBJECT`/`PURGE OLDER THAN` (§8.14), Tier 3 DCL `GRANT`/`REVOKE`/`SHOW GRANTS`/`DESCRIBE PRINCIPAL` over in-memory grant grains (§8.15, OMS §12.6), Tier 3 governance statements `APPROVE`/`REJECT`/`APPLY`/`ROLLBACK`/`RUN LOOP` + `DESCRIBE loop`-family (§8.16), principal-bound sessions and the credential/policy split (§18.4), authorization error codes CAL-E120--E125, and the `cal_tiers` conformance declaration. `DEFINE ROLE` reserved, deferred. Every 1.0--1.2 document remains valid Tier-0/1 CAL; a session without grants is exactly the language those releases promised -- the floor, not the ceiling. |
+| 1.3-draft | 2026-08-10 | **The pillar changes, on purpose and in the open.** 1.0--1.2 promised "non-destructive by grammar; no unsafe mode." The promise was true and had a hidden cost: real deployments still needed erasure -- GDPR, retention -- so destruction happened anyway, outside the language, ungoverned by any spec. Exiling destruction never prevented it; it only prevented *specifying* it. 1.3 brings it inside, where grammar bounds its shape (whole grains by hash, identity, or age -- never a predicate, never a key, no history rewrite, no `UNFORGET`), grants gate it per principal, and the audit trail sees it (a mandatory in-memory audit Observation per Tier-2 execution). Adds the four-tier model (Core/Evolve/Destroy/Control; tiers gate operations, not portability -- §2.2), Tier 2 statements `FORGET <hash>`/`FORGET SUBJECT`/`PURGE OLDER THAN` (§8.14), Tier 3 DCL `GRANT`/`REVOKE`/`SHOW GRANTS`/`DESCRIBE PRINCIPAL` over in-memory grant grains (§8.15, OMS §12.6), Tier 3 governance statements `APPROVE`/`REJECT`/`APPLY`/`ROLLBACK`/`RUN LOOP` + `DESCRIBE loop`-family (§8.16), principal-bound sessions and the credential/policy split (§18.4), authorization error codes CAL-E121--E126, and the `cal_tiers` conformance declaration. `DEFINE ROLE` reserved, deferred. Every 1.0--1.2 document remains valid Tier-0/1 CAL; a session without grants is exactly the language those releases promised -- the floor, not the ceiling. |
 | 1.2 | 2026-08-03 | As part of the OMS v1.5 release, adds the **Recommendation** grain type (`0x0C`) to the closed query set: `RECALL recommendations` with a type-specific field set (`target_ref`, `analyzer`, `severity`, `dedup_key`, `rec_status`), `<recommendation>` content projection, TOON columns, `recommendation_field` grammar production, and the type in `grain_type_plural`/`grain_type_singular`, `DESCRIBE`, and the JSON `valid_values` enum. Recommendation is **query-only** — it is engine-emitted and lifecycle-gated, so it is deliberately absent from the CAL-addable set (`ADD`/`SUPERSEDE SET` never create or transition a recommendation). Also adds the **`ELEMENT` shorthand** for custom templates (Section 10.6.1): `DEFINE TEMPLATE <name> AS "<text>"` and `FORMAT TEMPLATE "<text>"`, both defined by equivalence to an `ELEMENT` section, plus the `template_shorthand` production and `"TEMPLATE" , string_literal` in `format_spec`. This also corrects two 1.1 defects in the same examples (Sections 10.1.1, 14.2.1, 27): the `TEMPLATE "..."` form they use was not admitted by the Section 4 grammar, and they interpolated bare `{{subject}}`/`{{object}}` rather than the `grain.` namespace that Section 10.5 defines and Section 10.8 closes. Backward-compatible. |
 | 1.1 | 2026-03-05 | Multi-format output: FORMAT and AS clauses accept bracketed format lists (`FORMAT [markdown, json]`). Single query execution produces multiple renderings. New Section 10.1.1 (syntax and rules), Section 14.2.1 (multi-format response shape), error code CAL-E110. Backward-compatible — single-format syntax unchanged. As part of the OMS v1.4 release, also adds the Skill grain type (`0x0B`) to the closed query set (`RECALL skills` / `ADD skill`, type-specific field set, `<skill>` projection, TOON columns, `mg:capable_of` in the `AGENCY` shortcut) and corrects `belief`/`action` literals the rename left behind (`grain_type_plural`, `RECALL MY`, TOON tables, `DESCRIBE` listing, `CAL-E051`). |
 | 1.0 | 2026-03-03 | Initial CAL specification. 12-variant statement model. Tier 0 (RECALL, ASSEMBLE, SetOp, EXISTS, HISTORY, EXPLAIN, DESCRIBE, BATCH, COALESCE) + Tier 1 (ADD, SUPERSEDE, REVERT). ASSEMBLE with budget, priority, format, streaming. Semantic shortcuts (ABOUT, RECENT, SINCE, LIKE, MY, CONTRADICTIONS, BETWEEN). LET bindings. Custom FORMAT templates (Mustache-subset). Grain-type-specific queryable fields for all 10 OMS types. mg: relation vocabulary with category shortcuts. Domain profile querying. Dual wire format (text/cal + application/json+cal). Internationalization (Unicode NFC, cross-lingual search, bidi safety). Streaming protocol (SSE, NDJSON, WebSocket). THREAD shorthand. HISTORY AS OF and DIFF. Non-destructive safety model. Content Projection Model with flat semantic output (Section 10.3-10.4). PROJECT clause for custom field surfacing. Per-grain-type content projection rules with humanize() and time humanization. ELEMENT/ELEMENT_SUMMARY/SOURCE_BREAK template sections for flat semantic rendering. TOON (Token-Oriented Object Notation) format support — `toon` as a first-class FORMAT/AS preset (Section 10.9): tabular CSV rendering for uniform RECALL results, grouped-section rendering for ASSEMBLE results, per-grain-type column sets at each disclosure level, PROJECT integration, STREAM compatibility, auto-TOON budget-pressure hint (CAL-W005). |

--- a/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
+++ b/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
@@ -127,7 +127,7 @@ The line between the append-only tiers (0/1) and Tier 2 is: **can the operation 
 
 ### 1.5 Relationship to OMS
 
-CAL operates on the 12 grain types defined by OMS v1.6: Fact, Event, State, Workflow, Tool, Observation, Goal, Reasoning, Consensus, Consent, Skill, Recommendation. CAL treats this as a **closed set** -- custom types are not queryable via CAL.
+CAL operates on the 13 grain types defined by OMS v1.6: Fact, Event, State, Workflow, Tool, Observation, Goal, Reasoning, Consensus, Consent, Skill, Recommendation, Trigger. CAL treats this as a **closed set** -- custom types are not queryable via CAL.
 
 CAL extends the Store Protocol Convention defined in OMS §28.4 ([SPECIFICATION.md](./SPECIFICATION.md)) with a formal query language. Where OMS defines the `query`, `search`, and `supersede` store operations, CAL provides a structured, deterministic syntax for invoking them safely.
 
@@ -266,7 +266,7 @@ recall_priority, epistemic_status
 ```
 role, session_id, parent_message_id, model_id, content,
 context, plan,
-trigger, nodes, edges, bindings, retries,
+nodes, edges, bindings, retries,
 tool_name, tool_phase, is_error, tool_call_id,
 observer_id, observer_type,
 goal_state, assigned_agent, deadline, depends_on,
@@ -455,7 +455,7 @@ grain_field_name = event_field | state_field | workflow_field
 
 event_field     = "role" | "session_id" | "parent_message_id" | "model_id" | "content" ;
 state_field     = "context" | "plan" ;
-workflow_field  = "trigger" | "node" | "binding" ;
+workflow_field  = "node" | "binding" ;
 action_field    = "tool_name" | "tool_phase" | "is_error" | "tool_call_id" ;
 observation_field = "observer_id" | "observer_type" ;
 goal_field      = "goal_state" | "assigned_agent" | "deadline" | "depends_on" ;
@@ -569,12 +569,14 @@ run_loop_stmt   = "RUN" , "LOOP" , [ "FULL" ] , [ with_clause ] ;
 (* --- Workflow graph syntax --- *)
 
 workflow_add_stmt       = "ADD" , "workflow" , string_literal ,
-                          [ on_clause ] , graph_line , { graph_line } ,
+                          graph_line , { graph_line } ,
                           { bind_clause } , reason_clause ;
 workflow_supersede_stmt = "SUPERSEDE" , hash_literal ,
-                          [ on_clause ] , graph_line , { graph_line } ,
+                          graph_line , { graph_line } ,
                           { bind_clause } , reason_clause ;
-on_clause               = "ON" , string_literal ;
+(* `on_clause` removed in 1.3: it set OMS's `Workflow.trigger`, which 1.6
+   removes. A trigger is a Trigger grain that names its workflow (OMS §8.13).
+   "ON" remains a keyword, used by GRANT and REVOKE. *)
 bind_clause             = "BIND" , node_name , "=" , hash_literal ;
 
 graph_line              = node_or_group , { "->" , node_or_group , [ when_mod ] , [ repeat_mod ] } ;
@@ -614,11 +616,13 @@ positive_integer = digit+ ;
 
 grain_type_plural   = "facts" | "events" | "states" | "workflows" | "tools"
                     | "observations" | "goals" | "reasonings" | "consensuses"
-                    | "consents" | "skills" | "recommendations" ;
+                    | "consents" | "skills" | "recommendations"
+                    | "triggers" ;
 
 grain_type_singular = "fact" | "event" | "state" | "workflow" | "tool"
                     | "observation" | "goal" | "reasoning" | "consensus"
-                    | "consent" | "skill" | "recommendation" ;
+                    | "consent" | "skill" | "recommendation"
+                    | "trigger" ;
 ```
 
 ---
@@ -641,6 +645,7 @@ grain_type_singular = "fact" | "event" | "state" | "workflow" | "tool"
 | Consent | `consents` | `consent` | 0x0A |
 | Skill | `skills` | `skill` | 0x0B |
 | Recommendation | `recommendations` | `recommendation` | 0x0C |
+| Trigger | `triggers` | `trigger` | 0x0D |
 
 ### 5.2 Common Field Types
 
@@ -737,7 +742,6 @@ All Fact fields are in the common set (`subject`, `relation`, `object`, `confide
 
 | Field | Type | Operators | Notes |
 |-------|------|-----------|-------|
-| `trigger` | String | `=`, `!=` | Trigger condition (e.g., `"on:merge_to_main"`) |
 | `node` | String | `=` | Match workflows containing a specific node |
 | `binding` | String | `=` | Match workflows binding to a specific Tool grain hash |
 
@@ -819,6 +823,29 @@ All Fact fields are in the common set (`subject`, `relation`, `object`, `confide
 Recommendation grains are engine-emitted proposals and are **not CAL-addable** — like Events, Tools, and States, they are absent from the addable whitelist enforced by `CAL-E051` (Appendix C). `RECALL recommendations` reads the proposal queue, and lifecycle transitions occur only through the host's review/apply path (§8.12.1 of the OMS spec), never via `ADD`/`SUPERSEDE SET`.
 
 > **Note — why `rec_status` is type-scoped:** `verification_status` is a `meta_field_name` (§4), queryable on every grain type. `rec_status` is instead a `recommendation_field`, because it is meaningful only for this one type — a Recommendation's review state has no analogue on a Fact or an Event. Both are index-layer fields in OMS (§6.1 of the OMS spec); the asymmetry in CAL is deliberate scoping, not an oversight.
+
+#### Trigger (0x0D) -- `RECALL triggers`
+
+| Field | Type | Operators | Notes |
+|-------|------|-----------|-------|
+| `kind` | String | `=`, `!=`, `IN` | `"interval"`, `"schedule"`, `"once"`, `"polling"`, `"memory"`, `"webhook"`, `"manual"`, `"composite"` |
+| `workflow` | String | `=`, `IN` | Content address of the Workflow this trigger starts |
+| `connector` | String | `=`, `!=`, `IN` | External system name, e.g. `"gmail"` |
+| `scope` | String | `=`, `CONTAINS`, `STARTS WITH` | What is watched |
+| `enabled` | Boolean | `=`, `!=` | Whether the trigger is live |
+| `cron` | String | `=`, `CONTAINS` | Calendar expression |
+
+These are **first-class fields, not `context` keys**, which is the point: a
+trigger's cadence and target must be filterable. `RECALL triggers WHERE enabled
+= true AND connector = "gmail"` is the query this type exists to make possible,
+and it is why §8.13 of the OMS spec declares them rather than carrying them in a
+`context`-shaped map. Connector transport configuration remains in `config` and
+is not queryable.
+
+Operational state — when a trigger last fired, where its cursor is, whether it
+is currently claimed — is deliberately **not** in the grain and therefore not
+queryable through CAL. It is host-local (OMS §27.8) and does not travel with the
+memory.
 
 ### 6.4 Type-Specific ADD Extensions
 
@@ -1180,32 +1207,27 @@ Workflows use a dedicated graph syntax instead of SET clauses. The graph is expr
 ```sql
 -- Simple linear workflow
 ADD workflow "nightly backup"
-  ON "cron 0 2 * * *"
   snapshot -> compress -> upload
   REASON "automate database backups"
 
 -- Parallel fork/join
 ADD workflow "code review"
-  ON "PR opened"
   lint -> (security_review, compliance_review) -> evaluate
   REASON "parallel review gates"
 
 -- Conditional branching
 ADD workflow "release gate"
-  ON "review complete"
   evaluate -> implement WHEN "approved"
   evaluate -> reject WHEN "rejected"
   REASON "approval-based routing"
 
 -- Retry on failure
 ADD workflow "resilient deploy"
-  ON "release"
   build -> deploy * 3 -> notify
   REASON "retry deploy up to 3 times"
 
 -- Full pipeline with bindings
 ADD workflow "release pipeline"
-  ON "merge to main"
   build -> (unit_test, lint) -> integration_test
   integration_test -> stage_deploy * 3
   stage_deploy -> approval
@@ -1219,7 +1241,7 @@ ADD workflow "release pipeline"
   REASON "standard release process"
 ```
 
-**Clause order (fixed):** name → ON → graph lines → BIND → REASON
+**Clause order (fixed):** name → graph lines → BIND → REASON
 
 **Graph operators:**
 
@@ -1255,7 +1277,6 @@ SUPERSEDE sha256:target_hash
 
 ```sql
 SUPERSEDE sha256:abc123...
-  ON "merge to main"
   build -> (unit_test, lint, security_scan) -> integration_test
   integration_test -> canary_deploy * 3
   canary_deploy -> approval
@@ -1671,7 +1692,8 @@ Each grain type defines a **content rule** (what becomes the text content of the
 | **Observation** | `object` (what was observed) | `observer`? |
 | **Reasoning** | `conclusion` | `type`? |
 | **State** | `plan` (summary) | `context`? |
-| **Workflow** | `nodes` (joined as readable text) | `trigger`? |
+| **Workflow** | `nodes` (joined as readable text) | `name`? |
+| **Trigger** | what the rule watches | `kind`, `scope`? |
 | **Consensus** | `object` (the agreed claim) | `threshold`?, `count`? |
 | **Consent** | `purpose` | `action`, `grantor`, `grantee` |
 | **Skill** | `description` (what the skill enables) | `name`, `proficiency`?, `domain`? |
@@ -1887,7 +1909,7 @@ A template that needs more than one section — a `HEADER`, a `FOOTER`, an
 explicit `ELEMENT_SUMMARY`, a `SOURCE_BREAK` — MUST use the section list. A
 definition MUST NOT combine the two forms.
 
-**All 12 grain types rendered:**
+**All 13 grain types rendered:**
 ```sml
 <context intent="helping alice prepare her Q1 engineering review">
 
@@ -1913,7 +1935,7 @@ definition MUST NOT combine the two forms.
 
   <state context="q1_review_prep">outlining slides: 1. headline metrics  2. incident retrospective  3. velocity trend  4. Q2 goals</state>
 
-  <workflow trigger="review_prep_requested">retrieve_metrics -> identify_narrative -> draft_outline -> populate_data -> send_for_review</workflow>
+  <workflow name="review prep">retrieve_metrics -> identify_narrative -> draft_outline -> populate_data -> send_for_review</workflow>
 
   <consensus threshold="3" count="4">Q1 deployment frequency improved 18% over Q4 2025</consensus>
 
@@ -2020,11 +2042,12 @@ Where:
 | `observations` | `observer`, `content` |
 | `reasonings` | `type`, `content` |
 | `states` | `context`, `content` |
-| `workflows` | `trigger`, `content` |
+| `workflows` | `name`, `content` |
 | `consensuses` | `threshold`, `count`, `content` |
 | `consents` | `grantor`, `grantee`, `action`, `content` |
 | `skills` | `name`, `content`, `proficiency` |
 | `recommendations` | `target`, `content`, `severity` |
+| `triggers` | `kind`, `content` |
 
 At `summary` disclosure, `confidence`, `state`, `phase`, and `type` columns are omitted.
 At `full` disclosure, additional columns `source` and `observed` are appended.
@@ -2444,7 +2467,8 @@ Each grain type projects its fields into a **text content** string and **attribu
 | Observation | `object` | `<observation observer="system">alice opened incident-dashboard at 09:14 UTC</observation>` |
 | Reasoning | `conclusion` | `<reasoning type="deductive">alice is prioritising reliability given 3 P0 incidents; lead with incident reduction narrative</reasoning>` |
 | State | `plan` summary | `<state context="q1_review_prep">outlining slides: 1. headline metrics  2. incident retrospective  3. velocity trend  4. Q2 goals</state>` |
-| Workflow | `nodes` joined | `<workflow trigger="review_prep_requested">retrieve_metrics -> identify_narrative -> draft_outline -> populate_data -> send_for_review</workflow>` |
+| Workflow | `nodes` joined | `<workflow name="review prep">retrieve_metrics -> identify_narrative -> draft_outline -> populate_data -> send_for_review</workflow>` |
+| Trigger | what it watches | `<trigger kind="polling" scope="mailbox:accounts@example.com">poll the accounting mailbox every 2 minutes for invoices</trigger>` |
 | Consensus | `object` | `<consensus threshold="3" count="4">Q1 deployment frequency improved 18% over Q4 2025</consensus>` |
 | Consent | `purpose` | `<consent action="granted" grantor="alice" grantee="agent">access engineering metrics dashboards for review preparation</consent>` |
 | Skill | `description` | `<skill name="incident_retro" proficiency="0.82" domain="engineering">run a blameless incident retrospective and distil the recurring themes</skill>` |
@@ -3413,7 +3437,7 @@ ROLE                                        -- DEFINE ROLE, deferred (§3.2)
 | Event | `content` | String | `=` |
 | State | `context` | String | `=`, `!=` |
 | State | `plan` | String | `=` |
-| Workflow | `trigger` | String | `=`, `!=` |
+| Workflow | `node` | String | `=` |
 | Workflow | `node` | String | `=` |
 | Workflow | `binding` | String | `=` |
 | Tool | `tool_name` | String | `=`, `!=`, `IN` |

--- a/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
+++ b/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
@@ -3067,8 +3067,12 @@ It can read, assemble, and evolve memories, but never delete them.
 
 ### Rules:
 - LIMIT is always enforced (default 20, max 1000)
-- CAL cannot delete, erase, forget, or destroy data.
-- REASON is mandatory for all evolve operations.
+- CAL cannot rewrite history. Assume you cannot delete, erase, forget, or
+  destroy data: destruction and GRANT/APPROVE-class statements execute only
+  for sessions explicitly granted them -- check DESCRIBE capabilities before
+  attempting any, and expect CAL-E120/E121 refusals otherwise.
+- REASON is mandatory for all evolve operations; BECAUSE is mandatory for
+  governance and bulk-erasure statements.
 - Use HISTORY to check current version before SUPERSEDE.
 ```
 

--- a/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
+++ b/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
@@ -982,6 +982,7 @@ OMS defines a standard `mg:` relation vocabulary. CAL provides first-class suppo
 | `mg:handed_off_to` | Interaction | Agent DID | Agent DID | Agent handoff |
 | `mg:depends_on` | Lifecycle | Goal | Goal | Goal dependency |
 | `mg:assigned_to` | Agency | Task | Agent DID | Task assignment |
+| `mg:step_action:<node_id>` | Workflow | Tool grain | Workflow hash | Execution record: which node of a plan this Tool grain ran (OMS §8.4). **Parameterized** |
 
 ### 7.2 Relation Category Shortcuts
 
@@ -1011,6 +1012,12 @@ RECALL WHERE subject = "did:key:z6Mk..." AND relation IS PERMISSION
 ### 7.3 mg: Relation Validation
 
 The parser SHOULD validate `mg:` prefixed relation values against the known vocabulary. Unknown `mg:` relations produce warning `CAL-W001` (not an error).
+
+**Parameterized relations match by prefix.** A row marked *Parameterized* in
+§7.1 lists a prefix, not a value: `mg:step_action:node_3` is a member of the
+vocabulary. A validator matching only exact values warns `CAL-W001` on a
+relation OMS §8.4 defines normatively -- which is precisely what implementations
+did while this row was missing from the table.
 
 ---
 
@@ -2780,13 +2787,49 @@ When the query specifies a format list (`FORMAT [markdown, json]`), the response
 
 ### 14.3 Progressive Disclosure
 
+Progressive disclosure has **two orthogonal axes**, and prior revisions
+described only the first while the grammar (§4) admitted only the second --
+`disclosure_level` has been `summary | headlines | full` since 1.0, against a
+table naming `summary | standard | full`. Both axes are real; they are separate
+controls.
+
+**Axis 1 -- metadata density.** How many attributes each element carries. This
+is the axis the table below describes, and the default an implementation
+applies when no option is given:
+
 | Level | Metadata Density | When Used |
 |-------|-----------------|-----------|
 | `summary` | Tag name + subject + content only | Token budget tight (<1000 tokens) |
 | `standard` | + confidence, role, state, time | Default |
 | `full` | + source_type, importance, tags, verification_status | Token budget generous or LIMIT <= 5 |
 
-Progressive disclosure controls **metadata density on a flat structure**, not nesting depth. The element shape stays the same across all levels -- only the number of attributes changes.
+**Axis 2 -- body extent.** How much of each grain's free-text *body* survives
+the render. This is what `WITH progressive_disclosure(<level>)` selects, and its
+levels are the grammar's:
+
+| Level | Body extent |
+|-------|-------------|
+| `summary` | Free-text bodies clipped to a short lead (a reference implementation uses 40 characters) |
+| `headlines` | Clipped to a longer lead (a reference implementation uses 80 characters) |
+| `full` | Bodies whole, **and** the long-form definition text no other level carries -- a Skill's `instructions` and `when_to_use` |
+
+`full` is additive rather than merely unclipped: the long-form fields are
+omitted at every other level regardless of budget, because they are the fields
+that dominate a Skill grain's token cost.
+
+The bare option (`WITH progressive_disclosure`, no level) means `full`.
+**Omitting the option entirely is not a level** -- it leaves each format's
+established output unchanged, which is what keeps the option additive for
+callers who never passed it.
+
+The two axes compose: an element may carry full metadata over a clipped body,
+or minimal metadata over a whole one. Neither axis controls nesting depth --
+the element shape is flat and stays the same at every level, on both axes.
+
+This is the same ladder as OMS §10.5's tier model and the `ELEMENT_SUMMARY` /
+`ELEMENT_OMIT` template sections (§10.6): one mechanism -- degrade the body
+before dropping the grain -- surfaced as a query option, a template section, and
+a budget-pressure fallback.
 
 ### 14.4 Per-Grain-Type Content Projection
 
@@ -3873,6 +3916,6 @@ ROLE                                        -- DEFINE ROLE, deferred (§3.2)
 
 **Document Status:** This is the CAL (Context Assembly Language) Specification v1.3, **draft for comment**. It defines a deterministic, LLM-native context assembly, evolution, destruction, and control language for OMS-compliant memory databases — append-only by construction for evolution, authorization-gated for destruction and control. CAL is part of the Open Memory Specification (OMS) v1.6 draft — see [SPECIFICATION.md](./SPECIFICATION.md).
 
-**Last Updated:** 2026-08-10
+**Last Updated:** 2026-08-19
 **License:** This specification is offered under the Open Web Foundation Final Specification Agreement (OWFa 1.0)
 **Copyright:** Public Domain (CC0 1.0 Universal)

--- a/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
+++ b/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
@@ -467,7 +467,8 @@ relation_shortcut = "relation" , "IS" , relation_category ;
 domain_field_condition = domain_field , comparator , value ;
 
 domain_field    = domain_prefix , ":" , identifier ;
-domain_prefix   = "hc" | "legal" | "fin" | "rob" | "sci" | "con" | "int" ;
+domain_prefix   = "hc" | "legal" | "fin" | "rob" | "sci" | "con" | "int"
+                | "mail" ;   (* new in 1.3, OMS Appendix A.8 *)
 
 relation_category = "PREFERENCE" | "KNOWLEDGE" | "PERMISSION" | "INTERACTION"
                   | "AGENCY" | "LIFECYCLE" | "OBSERVATION" ;
@@ -2608,7 +2609,13 @@ If a source fails, its allocated budget is redistributed and a revised `budget_a
 
 ## 12. Domain Profile Querying
 
-OMS defines domain profiles (healthcare, legal, finance, robotics, science, consumer, integration). CAL provides structured access to domain-tagged grains.
+OMS defines domain profiles (healthcare, legal, finance, robotics, science, consumer, integration, mail). CAL provides structured access to domain-tagged grains.
+
+`domain_prefix` is a **closed** production (§4), so a new OMS profile is not
+usable from CAL until this specification admits its prefix. `mail:` is admitted
+in 1.3 alongside OMS Appendix A.8; the closure is deliberate -- an open prefix
+would make every misspelled field name a valid domain field rather than
+`CAL-E004`.
 
 ### 12.1 Profile Querying via Tags
 
@@ -2631,6 +2638,7 @@ Domain-specific fields use OMS domain prefix convention:
 | Science | `sci:` | `sci:experiment_id`, `sci:dataset_id`, `sci:methodology`, `sci:reproducibility_status` |
 | Consumer | `con:` | `con:session_context`, `con:interaction_channel` |
 | Integration | `int:` | `int:source_system`, `int:correlation_id`, `int:sync_status` |
+| Mail | `mail:` | `mail:message_id`, `mail:from`, `mail:to`, `mail:subject`, `mail:folder` |
 
 **Example:**
 ```sql

--- a/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
+++ b/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
@@ -236,7 +236,7 @@ ORDER, BY, ASC, DESC, WITH, EXPLAIN, SCOPE,
 UNION, INTERSECT, EXCEPT,
 SELECT, COUNT, FIRST, GROUP, SUBJECTS, OBJECTS, HASHES, PROJECT,
 INCLUDE, EXCLUDE, IS, NULL, TRUE, FALSE,
-EXISTS, HISTORY, DESCRIBE, BATCH, COALESCE,
+EXISTS, HISTORY, DESCRIBE, BATCH, COALESCE, REPORT,
 ABOUT, RECENT, SINCE, LIKE, MY, CONTRADICTIONS, AS,
 FOR, FROM, BUDGET, PRIORITY, FORMAT,
 LET, THREAD,
@@ -267,6 +267,8 @@ QUERY, QUERIES, DESCRIPTION, DROP                         -- definition surface 
 (§8.16) and `RUN "<name>"` (§8.18.3). A saved query name is a **string
 literal**, so the two never collide -- `LOOP` is a keyword and can never be a
 quoted name.
+
+`SUBJECT` is shared: `FORGET SUBJECT` is Tier 2, and `REPORT SUBJECT` (§8.19) is the Tier-0 read over the same selector. `REPORT` itself is a Tier-0 keyword -- disclosure is a read at every tier, and a host that has disabled destruction still answers access requests.
 
 `BECAUSE` was already an alias of `REASON` in `reason_clause`; Tier 2/3 statements conventionally write `BECAUSE`, and this specification uses that spelling for them throughout. `DEFINE ROLE` is **reserved but not specified** in 1.3 -- role bundles are deferred to a future revision; the 1.3 grant surface is verbs-only.
 
@@ -341,7 +343,7 @@ extractor       = "SUBJECTS" | "OBJECTS" | "HASHES" ;
 
 statement       = explain_stmt | recall_stmt | assemble_stmt | set_stmt
                 | exists_stmt | history_stmt | describe_stmt | batch_stmt
-                | coalesce_stmt | run_query_stmt
+                | coalesce_stmt | run_query_stmt | report_subject_stmt
                 | add_stmt | supersede_stmt | revert_stmt
                 | forget_stmt | purge_stmt                        (* Tier 2 *)
                 | grant_stmt | revoke_stmt | show_grants_stmt     (* Tier 3 *)
@@ -562,6 +564,9 @@ evolve_field    = "object" | "confidence" | "importance" | "tags" ;
 reason_clause   = ( "REASON" | "BECAUSE" ) , string_literal ;
 
 (* --- Tier 2: Destroy (new in 1.3) --- *)
+
+(* Tier 0: the read-only mirror of FORGET SUBJECT -- §8.19 *)
+report_subject_stmt = "REPORT" , "SUBJECT" , string_literal , [ with_clause ] ;
 
 forget_stmt     = "FORGET" , ( hash_literal | parameter ) , [ reason_clause ]
                 | "FORGET" , "SUBJECT" , string_literal ,
@@ -1747,6 +1752,49 @@ find what it may `RUN`.
 
 `DESCRIBE capabilities` SHOULD report saved-query support and the limits of
 §8.18.2.
+
+
+### 8.19 REPORT SUBJECT (Tier 0 -- new in 1.3)
+
+The read-only mirror of `FORGET SUBJECT`: the same selection, disclosed instead
+of destroyed. It is the in-language answer to GDPR Art. 15 (access) and Art. 20
+(portability), and the safe rehearsal for an erasure.
+
+```sql
+REPORT SUBJECT "pat"
+REPORT SUBJECT "pat" WITH text_mentions
+```
+
+**One selector, two verbs.** `REPORT SUBJECT <id>` MUST select exactly the set
+`FORGET SUBJECT <id>` would erase, through the same code path and the same
+indexes (OMS §28.4.4 rule 3) -- the identity, its partition-style derived keys,
+grains carrying it in either triple position, its thread and run records, and
+under `WITH text_mentions` its indexed text mentions. `WITH text_mentions`
+carries the same hard precondition on both statements: where the text index is
+absent or incomplete the statement MUST refuse rather than return a quietly
+partial answer.
+
+Sharing the selector is the point. It makes "show me everything you hold, then
+delete it" two statements over one set, and it means a disclosure cannot
+promise less than an erasure removes or more than it reaches.
+
+**It is a read, and it is classified as one.** `REPORT SUBJECT` requires the
+`read` verb, not `erase`. It MUST NOT sit behind whatever process-level cap
+disables destructive operations: a deployment that has turned destruction off
+still owes data subjects access, and coupling the two would make an
+implementation choose between refusing erasure and refusing disclosure.
+
+**It writes nothing.** No audit Observation, no grain of any kind. Tier 2 writes
+an audit record because destruction is irreversible and its record must outlive
+it (§8.14.4); an access request destroys nothing and needs no such record. A
+host that logs access does so in host logs, not in memory -- and an audit grain
+naming the subject of a DSAR would itself become personal data about that
+subject, in an immutable replicating store.
+
+**Result.** The response carries every matched identity string (so the requester
+can see *which* keys matched, including derived ones) and the selected grains.
+Hosts SHOULD also offer the result as a portable export, since Art. 20 asks for
+a machine-readable form rather than a rendering.
 
 
 ---
@@ -3040,10 +3088,10 @@ CAL queries execute through the same read path as all other interfaces. No CAL s
 
 ### 19.2 GDPR Implications
 
-- **Art. 15 (Right of Access):** CAL enables DSAR via `RECALL WHERE user_id = "alice" COUNT`
+- **Art. 15 (Right of Access):** `REPORT SUBJECT "<id>"` (Tier 0, `read` verb, §8.19) -- the erasure selector in disclose-mode, so the answer matches what an erasure would remove.
 - **Art. 16 (Right to Rectification):** CAL SUPERSEDE enables correction of inaccurate personal data.
 - **Art. 17 (Right to Erasure):** Expressible in-language since 1.3 -- `FORGET SUBJECT <id> BECAUSE "..."` (Tier 2, `erase` verb, audited, one-way; §8.14). Hosts without Tier 2 continue to serve erasure via implementation-specific APIs.
-- **Art. 20 (Data Portability):** CAL can serve as query interface for exports.
+- **Art. 20 (Data Portability):** `REPORT SUBJECT` (§8.19), whose result hosts SHOULD offer as a portable export.
 - **Art. 25 (By Design):** Grammar-level safety qualifies as "by design" protection.
 
 ### 19.3 HIPAA Implications
@@ -3687,7 +3735,7 @@ EXISTS, HISTORY, DESCRIBE, BATCH, COALESCE,
 ABOUT, RECENT, SINCE, LIKE, MY, CONTRADICTIONS, AS,
 FOR, FROM, BUDGET, PRIORITY, FORMAT,
 LET, THREAD, DIFF,
-ADD, SUPERSEDE, REVERT, SET, REASON, BECAUSE, REHYDRATE,
+ADD, SUPERSEDE, REVERT, SET, REASON, BECAUSE, REHYDRATE, REPORT,
 FORGET, PURGE, SUBJECT, OLDER, THAN, TYPE,
 GRANT, REVOKE, ON, TO, SHOW, GRANTS, PRINCIPAL,
 APPROVE, REJECT, APPLY, ROLLBACK, RUN, LOOP, FULL,

--- a/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
+++ b/CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md
@@ -1,7 +1,14 @@
-# CAL (Context Assembly Language) Specification v1.2
+# CAL (Context Assembly Language) Specification v1.3
 
-**Status:** Standards Track | **Date:** 2026-08-03 | **Version:** 1.2 | **Classification:** Experimental
-**Part of:** [Open Memory Specification (OMS) v1.5](./SPECIFICATION.md)
+**Status:** Draft for Comment (CAL 1.3 RFC) | **Date:** 2026-08-10 | **Version:** 1.3-draft | **Classification:** Experimental
+**Part of:** [Open Memory Specification (OMS) v1.6 draft](./SPECIFICATION.md)
+
+> **Draft status.** Version 1.3 restates the safety pillar — from "non-destructive
+> by grammar" to **append-only by construction for evolution, authorization-gated
+> for destruction** — and adds the Tier 2 (Destroy) and Tier 3 (Control) statement
+> families. Every CAL 1.0–1.2 document remains valid, and a session without grants
+> is exactly the language 1.0–1.2 specified. Sections changed by this draft are
+> normative only upon release.
 ---
 
 ## Table of Contents
@@ -47,7 +54,7 @@
 
 The **Context Assembly Language (CAL)** is a companion specification to the Open Memory Specification (OMS). It defines a non-destructive, deterministic, LLM-native language for **assembling agent context from persistent memory**.
 
-CAL allows AI agents to **recall** memory, **assemble** context windows from multiple memory sources with budget constraints, and **evolve** memory -- but never **destroy** it. Every write is append-only and fully revertible. The core safety guarantee -- that CAL cannot destroy data -- is enforced at the grammar level and is a structural impossibility, not a policy check.
+CAL allows AI agents to **recall** memory, **assemble** context windows from multiple memory sources with budget constraints, **evolve** memory append-only, and -- for principals explicitly granted the capability -- **destroy** whole grains (tombstone or bulk erasure) and **control** who may do which of those. The core safety guarantee is two-part: *history cannot be rewritten* (structural -- no statement mutates a stored blob, no destruction takes a predicate), and *destruction and control execute only for an authorized principal* (Tier 2/3, fail-closed). A session without grants is exactly the non-destructive CAL that versions 1.0--1.2 specified -- that language is the floor of every conforming implementation, not its ceiling.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
 
@@ -93,9 +100,10 @@ Key capabilities:
 
 ### 1.3 What CAL Is NOT
 
-- **Not SQL.** No tables, no joins, no DDL, no transactions.
+- **Not SQL.** No tables, no joins, no transactions. (Since 1.3, CAL does have a DCL -- `GRANT`/`REVOKE` -- the way SQL has since SQL-89.)
 - **Not Turing-complete.** No loops, no recursion, no persistent variables.
-- **Not a destructive language.** CAL cannot forget, erase, delete, or destroy grains. CAL cannot touch encryption keys, policies, or consent records. This is the core safety guarantee.
+- **Not an unguarded destructive language.** Destruction exists only as Tier 2: a tombstone of one grain by content address, or bulk erasure by identity or age -- never by predicate, and only for a principal granted `delete`/`erase`. CAL can never rewrite history: no statement mutates a stored blob. CAL cannot touch encryption keys or credentials -- ever, at any tier.
+- **Not an authentication or key-management system.** The host proves who a principal is, custodies keys, and transports files; CAL governs what an authenticated principal may do inside a memory.
 - **Not a transport protocol.** CAL defines a language. Transport (HTTP, gRPC, MCP, etc.) is implementation-specific.
 - **Not a rendering engine.** CAL's FORMAT clause specifies *semantic structure*, not pixel-level presentation. The agent or UI decides how to render.
 - **Not a storage mirror.** CAL output is a *projection* optimized for LLM consumption, not a serialization of the underlying OMS grain structure. Hashes, namespaces, and internal metadata stay in the machine envelope.
@@ -111,14 +119,15 @@ CAL's safety model maps directly to git:
 | `git add` + `git commit` (new file) | `ADD` | No (append-only) | Yes (Tier 1) |
 | `git commit` (amend existing) | `SUPERSEDE` | No (append-only) | Yes (Tier 1) |
 | `git revert` | `REVERT` | No (creates new commit) | Yes (Tier 1) |
-| `git reset --hard` | Store-level `delete` | **Yes** (destroys data) | **No** |
+| `git reset --hard` | -- (rewrites history) | **Yes** | **No -- structurally impossible** |
+| Repo deletion under admin rights | `FORGET` / `PURGE` | **Yes** (whole grains, one-way) | Tier 2 (authorization-gated) |
 | `git push --force` | Crypto-erasure | **Yes** (destroys keys) | **No** |
 
-The line between Tier 0/1 (in CAL) and Tier 2 (not in CAL) is: **can the operation be undone by another append-only operation?** If yes, it is safe for CAL. If no, it stays out.
+The line between the append-only tiers (0/1) and Tier 2 is: **can the operation be undone by another append-only operation?** If yes, it needs no special authority. If no -- a tombstone or an erasure -- it executes only for a principal explicitly granted it, it writes an audit Observation, and it is final: destruction takes a hash, an identity, or an age, never a predicate, and there is no un-forget. Key destruction stays out of the language entirely.
 
 ### 1.5 Relationship to OMS
 
-CAL operates on the 12 grain types defined by OMS v1.5: Fact, Event, State, Workflow, Tool, Observation, Goal, Reasoning, Consensus, Consent, Skill, Recommendation. CAL treats this as a **closed set** -- custom types are not queryable via CAL.
+CAL operates on the 12 grain types defined by OMS v1.6: Fact, Event, State, Workflow, Tool, Observation, Goal, Reasoning, Consensus, Consent, Skill, Recommendation. CAL treats this as a **closed set** -- custom types are not queryable via CAL.
 
 CAL extends the Store Protocol Convention defined in OMS §28.4 ([SPECIFICATION.md](./SPECIFICATION.md)) with a formal query language. Where OMS defines the `query`, `search`, and `supersede` store operations, CAL provides a structured, deterministic syntax for invoking them safely.
 
@@ -128,31 +137,38 @@ CAL extends the Store Protocol Convention defined in OMS §28.4 ([SPECIFICATION.
 
 ### 2.1 The Core Guarantee
 
-> **CAL cannot destroy data. This is not a policy check. It is a structural impossibility.**
+> **CAL cannot rewrite history. This is not a policy check. It is a structural impossibility.**
 >
-> CAL *can* evolve data -- by creating new grains that supersede old ones. But the old grains survive. Every evolution is traceable and revertible. Nothing is ever deleted.
+> CAL *can* evolve data -- by creating new grains that supersede old ones; the old grains survive, and every evolution is traceable and revertible. Since 1.3, CAL *can also* destroy whole grains -- a tombstone by content address, or bulk erasure by identity or age -- but **only** for a principal explicitly granted that verb, only with an audit Observation written, and only in a shape the grammar bounds: **a hash, an identity, or an age -- never a predicate, and never a key.** For any session without such grants, CAL is exactly the non-destructive language of versions 1.0--1.2.
 
 The guarantee is enforced at three reinforcing levels:
 
 | Level | Mechanism | What It Prevents |
 |-------|-----------|-----------------|
-| **Grammar** | The EBNF grammar has no production rules for destructive operations | Parser cannot produce destructive AST nodes |
-| **Type System** | `CalStatement` is a closed enum with exactly 12 variants: `Recall`, `Assemble`, `SetOp`, `Exists`, `History`, `Explain`, `Describe`, `Batch`, `Add`, `Supersede`, `Revert`, `Coalesce`. | No code path from AST to any destructive method |
-| **API Surface** | CAL executor receives a constrained facade, not the full store | Destructive methods (delete, key destruction) are structurally inaccessible |
+| **Grammar** | No production mutates a stored blob; no destruction production accepts a predicate (`FORGET WHERE` does not parse); no key/credential vocabulary exists | Parser cannot produce a history-rewriting or predicate-destruction AST node |
+| **Type System** | `CalStatement` is a closed, per-tier statement set (§8). Destruction variants exist only in the Tier 2 family; adding any other destructive variant requires modifying this specification | No code path from a read/evolve AST to any destructive method |
+| **Authorization + API Surface** | The executor receives a constrained facade; destructive facade methods execute only after the session principal's grants (OMS §12.6) allow the statement's verb; key management is never on the facade | Destruction without an authorized principal is refused fail-closed; key destruction is structurally inaccessible |
 
-### 2.2 Three-Tier Capability Model
+### 2.2 Four-Tier Capability Model
 
-| Tier | Name | What It Can Do | How It Is Enforced |
-|------|------|---------------|-------------------|
-| **Tier 0** | Read (default) | Query, count, explain, assemble, describe, batch. Cannot modify anything. | Grammar + type system. Default for all CAL sessions. |
-| **Tier 1** | Evolve (opt-in) | Add new grains, supersede existing grains, revert supersessions, view history. Append-only; never deletes. | Separate grammar extension, explicit server opt-in, separate capability token with write quotas. |
-| **Tier 2** | Lifecycle | Erasure, key rotation, policy changes, consent management. | **Does not exist in CAL.** No grammar, no AST, no parser extension, no config flag. Only available through implementation-specific APIs (REST, gRPC, CLI, etc.). |
+| Tier | Name | What It Can Do | Gate |
+|------|------|---------------|------|
+| **0** | Core (default) | Query, count, explain, assemble, describe, batch. Cannot modify anything. | None. Default for all CAL sessions. |
+| **1** | Evolve (opt-in) | Add new grains, supersede, revert, view history. Append-only; never deletes. | Server opt-in; `write`/`supersede` verbs where Tier 3 is implemented, capability token with write quotas otherwise. |
+| **2** | Destroy | `FORGET <hash>`, `FORGET SUBJECT`, `PURGE OLDER THAN`. Whole-grain tombstone and bulk erasure -- one-way, audited. | `delete`/`erase` verbs. Requires *an* authorization model: host-defined authorization suffices (Tier 2 without Tier 3 is legal). A host with no authorization model MUST refuse Tier 2. |
+| **3** | Control | `GRANT`/`REVOKE` (DCL), the governance lifecycle (`APPROVE`/`REJECT`/`APPLY`/`ROLLBACK`/`RUN LOOP`), principal-bound sessions. | `admin` and `loop.*` verbs; implies the grant model (OMS §12.6) that Tier 2 consumes. |
 
-### 2.3 Formal Safety Proofs
+**Tiers gate operations, not portability.** Interoperability rides the `.mg` file and Tier-0 reads: any Core implementation can read any memory. A read-only implementation declares Tier 0 and remains fully conformant forever -- nothing in Tier 2/3 is required of it. Hosts declare their tiers, and `DESCRIBE capabilities` MUST report them, so an agent (or a test suite) learns what it may attempt before attempting it.
 
-**"CAL cannot delete data because..."** The `CalStatement` enum has 12 variants. The executor's `match` is exhaustive (compiler-verified in statically typed languages). None invoke a delete or forget operation. Adding a delete variant requires modifying the specification.
+### 2.3 Formal Safety Claims
 
-**"CAL cannot trigger erasure because..."** Erasure requires access to key management or store-level delete operations. The CAL executor facade exposes only: `recall()`, `count()`, `exists()`, `add()`, `supersede()`, `revert()`, `get_history()`, `assemble()`, `describe()`. No key management or delete methods are accessible.
+**"CAL cannot rewrite history because..."** No statement mutates a stored blob. `SUPERSEDE` and `REVERT` create new grains and update index-layer fields only; `FORGET` tombstones a whole grain (the store's compliance `delete`, OMS §28.4) and is **one-way** -- there is no `UNFORGET`, and a host MUST NOT provide an un-tombstone mechanism. Additions roll back by *retraction* (a supersession with `invalidation_type: "retraction"`); tombstones and erasure are final.
+
+**"CAL destruction cannot happen without an authorized principal because..."** Every Tier-2 statement executes only after the session principal's grants allow its verb (`delete` for `FORGET <hash>`, `erase` for `FORGET SUBJECT`/`PURGE`). Sessions without grants are Tier 0/1. Enforcement is fail-closed: an unknown principal, an absent grant, or a host without an authorization model all refuse. Every Tier-2 execution writes an audit Observation grain (§8.14.4).
+
+**"CAL cannot destroy by predicate because..."** The destruction grammar accepts exactly three target shapes: a content address, a subject identity, or an age window. There is no production for `FORGET WHERE` or any filter-driven deletion, so a single statement's blast radius is always explicit in its text.
+
+**"CAL cannot trigger key destruction because..."** Crypto-erasure requires key management, and no key vocabulary exists in the grammar (§2.4) and no key method exists on the executor facade. Keys and credentials are host objects at every tier.
 
 **"CAL ADD cannot destroy data because..."** ADD creates a new grain via the OMS store `put` operation (OMS §28.4). It does not modify or reference any existing grain. The grain count increases by one.
 
@@ -166,19 +182,21 @@ The guarantee is enforced at three reinforcing levels:
 
 ### 2.4 Grammar-Level Exclusions
 
-The following tokens do **not exist** in CAL's lexer or grammar:
+The following tokens do **not exist** in CAL's lexer or grammar, at any tier:
 
 ```
-DELETE, DROP, FORGET, ERASE, DESTROY, PURGE, TRUNCATE,    -- Destructive
+DELETE, DROP, ERASE, DESTROY, TRUNCATE,                     -- Predicate/unbounded destruction
 INSERT, CREATE, WRITE, STORE,                               -- Unconstrained creation
-KEY, ENCRYPT, DECRYPT, ROTATE, MASTER, DEK, SECRET,        -- Key management
-POLICY, SEAL, UNSEAL, GRANT, REVOKE, CONSENT, RESTRICT,    -- Policy/auth
+KEY, ENCRYPT, DECRYPT, ROTATE, MASTER, DEK, SECRET, TOKEN,  -- Key/credential management
+POLICY, SEAL, UNSEAL, CONSENT, RESTRICT,                    -- Sealed policy / consent records
 SCHEMA, PARTITION, INDEX, MIGRATION                         -- Schema
 ```
 
-If these appear in a query, they are parse errors, not recognized keywords.
+If these appear in a query, they are parse errors, not recognized keywords. This list is permanent: no future tier unblocks it. (`POLICY` here means the sealed policy and loop-policy *writes*; the read-only `DESCRIBE policy` target is an identifier, not this keyword.)
 
-Note: `ADD`, `SUPERSEDE`, `REVERT`, `SET`, and `REASON` are Tier 1 keywords. The **parser** always recognizes them (so that `EXPLAIN ADD ...` works as a dry-run even when Tier 1 execution is disabled). However, the **executor** rejects non-EXPLAIN Tier 1 statements when Tier 1 is disabled, returning `CAL-E044: Tier1NotEnabled`. This two-layer approach ensures `EXPLAIN` can always preview evolve operations without risk.
+**Changed in 1.3:** `FORGET` and `PURGE` moved from this list to the Tier 2 keyword set, and `GRANT`/`REVOKE` to the Tier 3 keyword set (§3.2). The block on them existed to force a specification-level decision before any destructive or control surface entered the language -- this revision is that decision, and the statements it admits are bounded by §2.1--§2.3.
+
+Note: Tier 1/2/3 keywords are always **parsed** (so `EXPLAIN FORGET ...` works as a dry-run even where execution is unavailable). The **executor** rejects non-EXPLAIN statements above the session's effective tier: `CAL-E044: Tier1NotEnabled` for Tier 1, `CAL-E120`/`CAL-E121` for Tier 2/3 (§22). This two-layer approach ensures `EXPLAIN` can always preview an operation without risk.
 
 ---
 
@@ -213,6 +231,19 @@ CAL                                                       -- version prefix
 ```
 ADD, SUPERSEDE, REVERT, SET, REASON
 ```
+
+**Tier 2 (Destroy) keywords (new in 1.3; always parsed; execution requires the `delete`/`erase` verb -- see sections 2.2 and 8.13):**
+```
+FORGET, PURGE, SUBJECT, OLDER, THAN, TYPE, BECAUSE
+```
+
+**Tier 3 (Control) keywords (new in 1.3; always parsed; execution requires the `admin`/`loop.*` verbs -- see sections 8.14 and 8.15):**
+```
+GRANT, REVOKE, ON, TO, SHOW, GRANTS, PRINCIPAL,
+APPROVE, REJECT, APPLY, ROLLBACK, RUN, LOOP, FULL
+```
+
+`BECAUSE` was already an alias of `REASON` in `reason_clause`; Tier 2/3 statements conventionally write `BECAUSE`, and this specification uses that spelling for them throughout. `DEFINE ROLE` is **reserved but not specified** in 1.3 -- role bundles are deferred to a future revision; the 1.3 grant surface is verbs-only.
 
 **Relation category keywords:**
 ```
@@ -286,13 +317,18 @@ extractor       = "SUBJECTS" | "OBJECTS" | "HASHES" ;
 statement       = explain_stmt | recall_stmt | assemble_stmt | set_stmt
                 | exists_stmt | history_stmt | describe_stmt | batch_stmt
                 | coalesce_stmt | define_template_stmt
-                | add_stmt | supersede_stmt | revert_stmt ;
+                | add_stmt | supersede_stmt | revert_stmt
+                | forget_stmt | purge_stmt                        (* Tier 2 *)
+                | grant_stmt | revoke_stmt | show_grants_stmt     (* Tier 3 *)
+                | approve_stmt | reject_stmt | apply_stmt
+                | rollback_stmt | run_loop_stmt ;                 (* Tier 3 *)
 
 (* --- Tier 0: Read --- *)
 
 explain_stmt    = "EXPLAIN" , ( recall_stmt | assemble_stmt | set_stmt
                 | add_stmt | supersede_stmt | revert_stmt | batch_stmt
-                | coalesce_stmt ) ;
+                | coalesce_stmt
+                | forget_stmt | purge_stmt | grant_stmt | revoke_stmt ) ;
 
 set_stmt        = "(" , query , ")" , set_op , "(" , query , ")" ;
 set_op          = "UNION" | "INTERSECT" | "EXCEPT" ;
@@ -320,11 +356,14 @@ history_stmt    = "HISTORY" , ( hash_literal | parameter ) , [ diff_clause ]
 
 describe_stmt   = "DESCRIBE" , describe_target ;
 describe_target = "grain_types" | "fields" , [ grain_type_singular ]
-                | "capabilities" | "server" | "templates" | "grammar" ;
+                | "capabilities" | "server" | "templates" | "grammar"
+                | "PRINCIPAL" , principal                       (* Tier 3 read *)
+                | "loop" | "analyzers" | "outcomes" | "policy" ; (* Tier 3 reads *)
 
 batch_stmt      = "BATCH" , "{" , batch_entry , { "," , batch_entry } , "}" ;
 batch_entry     = label , ":" , ( recall_stmt | exists_stmt | history_stmt
                 | describe_stmt | coalesce_stmt ) ;
+                (* Tier 2/3 statements are NOT batch entries -- see §8.14.3 *)
 
 coalesce_stmt   = "COALESCE" , "(" , recall_stmt , "," , recall_stmt ,
                   { "," , recall_stmt } , ")" ;
@@ -491,6 +530,34 @@ observation_add_field = "observer_id" | "observer_type" ;
 set_clause      = "SET" , evolve_field , "=" , value ;
 evolve_field    = "object" | "confidence" | "importance" | "tags" ;
 reason_clause   = ( "REASON" | "BECAUSE" ) , string_literal ;
+
+(* --- Tier 2: Destroy (new in 1.3) --- *)
+
+forget_stmt     = "FORGET" , ( hash_literal | parameter ) , [ reason_clause ]
+                | "FORGET" , "SUBJECT" , string_literal ,
+                  [ with_clause ] , reason_clause ;
+purge_stmt      = "PURGE" , "OLDER" , "THAN" , duration_literal ,
+                  [ "TYPE" , grain_type_singular ] , reason_clause ;
+duration_literal = digit+ , ( "d" | "h" | "m" ) ;
+
+(* --- Tier 3: Control (new in 1.3) --- *)
+
+grant_stmt      = "GRANT" , verb_list , "ON" , ns_scope , "TO" , principal ,
+                  [ with_clause ] ;
+revoke_stmt     = "REVOKE" , verb_list , "ON" , ns_scope , "FROM" , principal ,
+                  [ with_clause ] ;
+show_grants_stmt = "SHOW" , "GRANTS" , [ "FOR" , principal ] ;
+verb_list       = verb , { "," , verb } ;
+verb            = "read" | "write" | "supersede" | "delete" | "erase"
+                | "loop.run" | "loop.review" | "loop.apply" | "admin" ;
+ns_scope        = identifier | string_literal | "*" ;
+principal       = identifier , ":" , identifier | string_literal ;
+
+approve_stmt    = "APPROVE"  , ( hash_literal | parameter ) , reason_clause ;
+reject_stmt     = "REJECT"   , ( hash_literal | parameter ) , reason_clause ;
+apply_stmt      = "APPLY"    , ( hash_literal | parameter ) , reason_clause ;
+rollback_stmt   = "ROLLBACK" , ( hash_literal | parameter ) , reason_clause ;
+run_loop_stmt   = "RUN" , "LOOP" , [ "FULL" ] , [ with_clause ] ;
 
 (* --- Workflow graph syntax --- *)
 
@@ -864,7 +931,7 @@ The parser SHOULD validate `mg:` prefixed relation values against the known voca
 
 ## 8. Statement Semantics
 
-CAL/1 has **12 statement types** organized into three tiers:
+CAL/1 statements are organized into four tiers (§2.2):
 
 | Statement | Tier | Description |
 |-----------|------|-------------|
@@ -872,14 +939,20 @@ CAL/1 has **12 statement types** organized into three tiers:
 | **ASSEMBLE** | 0 | Compose context from multiple sources with budget |
 | **EXISTS** | 0 | Check grain existence by content address |
 | **HISTORY** | 0 | Version history with AS OF and DIFF |
-| **EXPLAIN** | 0 | Execution plan preview |
-| **DESCRIBE** | 0 | Schema introspection |
+| **EXPLAIN** | 0 | Execution plan preview (any tier's statement, as dry-run) |
+| **DESCRIBE** | 0 | Schema introspection (`PRINCIPAL`/`loop`-family targets read Tier-3 state) |
 | **BATCH** | 0 | Multiple independent queries in one request |
 | **COALESCE** | 0 | Fallback chain of RECALL queries |
+| *Set operations* | 0 | `UNION`, `INTERSECT`, `EXCEPT` |
 | **ADD** | 1 | Create a new grain (append-only) |
 | **SUPERSEDE** | 1 | Create a new version of an existing grain |
 | **REVERT** | 1 | Restore a previous version |
-| *Set operations* | 0 | `UNION`, `INTERSECT`, `EXCEPT` |
+| **FORGET** | 2 | Tombstone one grain by hash, or erase a subject's grains (§8.14) |
+| **PURGE** | 2 | Age-scoped retention erasure (§8.14) |
+| **GRANT / REVOKE** | 3 | Confer or withdraw verbs on a namespace for a principal (§8.15) |
+| **SHOW GRANTS** | 3 (read) | List live grants (§8.15) |
+| **APPROVE / REJECT / APPLY / ROLLBACK** | 3 | Recommendation lifecycle transitions (§8.16) |
+| **RUN LOOP** | 3 | Trigger an analysis pass of the host's improvement engine (§8.16) |
 
 ### 8.1 RECALL (Tier 0)
 
@@ -1209,6 +1282,156 @@ COALESCE(
 ```
 
 **Constraints:** Max 5 branches. All branches MUST be RECALL statements.
+
+### 8.14 FORGET and PURGE (Tier 2 -- new in 1.3)
+
+Destruction of whole grains, in exactly three shapes. Maps to the OMS store's
+compliance `delete` operation (OMS §28.4) and host bulk-erasure operations.
+
+```sql
+FORGET sha256:a1b2c3d4...                                   -- one grain, by address
+FORGET sha256:a1b2c3d4... BECAUSE "user retracted consent"  -- reason optional here, recorded when given
+FORGET SUBJECT "patient-789" BECAUSE "GDPR Art. 17 request" -- every grain referencing an identity
+FORGET SUBJECT "patient-789" WITH text_mentions BECAUSE "…" -- + grains whose indexed text mentions it
+PURGE OLDER THAN 90d BECAUSE "retention policy"             -- age-scoped sweep
+PURGE OLDER THAN 30d TYPE event BECAUSE "transcript TTL"    -- age + one grain type
+```
+
+#### 8.14.1 Semantics
+
+- `FORGET <hash>` tombstones one grain: it leaves the default recall path
+  permanently. Requires the `delete` verb. `BECAUSE` is OPTIONAL on this form
+  (it predates 1.3 in deployed dialects and MUST remain valid without a
+  reason) and MUST be recorded in the audit Observation when given.
+- `FORGET SUBJECT <id>` erases every grain referencing the identity --
+  history included -- per the host's erasure procedure; `WITH text_mentions`
+  extends the scope to grains whose indexed text mentions the identity.
+  Requires the `erase` verb. `BECAUSE` is REQUIRED (parse error without).
+- `PURGE OLDER THAN <duration> [TYPE <t>]` erases grains older than the
+  window, optionally limited to one grain type. Requires the `erase` verb.
+  `BECAUSE` is REQUIRED.
+- All three are **one-way** (§2.3): there is no `UNFORGET`, and a host MUST
+  NOT offer an un-tombstone or un-erase mechanism through any interface.
+- An erasure execution SHOULD produce the host's erasure report; the audit
+  Observation (§8.14.4) references it.
+
+#### 8.14.2 Authorization
+
+Tier-2 statements execute only when the session principal (§18.4) holds the
+required verb for the target namespace, resolved from the memory's own grant
+grains (OMS §12.6) or, on a Tier-2-without-Tier-3 host, from the host's
+authorization model. Enforcement is fail-closed: no principal, no grants, or
+no authorization model at all → `CAL-E120`/`CAL-E121`, nothing executes.
+A host session designated *owner* (OMS §12.6.4) is exempt from grant lookup.
+
+#### 8.14.3 Context restrictions
+
+Tier-2 and Tier-3 statements MUST be top-level, single statements. They are
+refused inside `BATCH`, inside saved-query bodies, and inside a
+Recommendation's `proposal_cal` **except** that a `proposal_cal` MAY carry
+Tier-2 statements where the host authorizes destructive proposals (OMS
+§8.12); governance statements (§8.16) are refused inside `proposal_cal`
+unconditionally. `EXPLAIN` of any Tier-2/3 statement is always available as
+a dry-run and executes nothing.
+
+#### 8.14.4 The Tier-2 audit Observation
+
+Every Tier-2 execution MUST write one audit Observation grain in the memory
+it acted on, following the audit pattern of OMS §8.12.1: `observer_id` = the
+session principal, `observer_type` from the principal's host record (§18.4),
+the statement's verb and target (hash, subject identity, or age window) and
+the `BECAUSE` reason (where given) carried in the Observation's `object`,
+and `derived_from` referencing the erasure report where one exists. The
+audit grain is ordinary memory: it replicates with the file and is
+`RECALL`-able. A destruction that cannot write its audit Observation MUST
+fail before destroying anything.
+
+### 8.15 GRANT, REVOKE, SHOW GRANTS (Tier 3 -- new in 1.3)
+
+The control plane: confer or withdraw verbs on a namespace for a principal.
+Grants are stored **in the memory itself** as grant grains (OMS §12.6) --
+they travel, replicate, and are queryable like any other memory.
+
+```sql
+GRANT read, write ON caller TO agent:support-bot
+GRANT delete ON * TO user:anna WITH because("support rotation")
+REVOKE write ON caller FROM agent:support-bot WITH because("offboarded")
+SHOW GRANTS                          -- every live grant
+SHOW GRANTS FOR agent:support-bot    -- one principal's live grants
+DESCRIBE PRINCIPAL agent:support-bot -- effective verbs per namespace
+```
+
+#### 8.15.1 Semantics
+
+- **Verbs:** `read`, `write`, `supersede`, `delete`, `erase`, `loop.run`,
+  `loop.review`, `loop.apply`, `admin`. The verb set is closed in 1.3.
+- **Scope:** one namespace or `*`. The memory axis is implicit -- a grant
+  governs the memory it is stored in, never another memory.
+- **Principals** are opaque names (`user:anna`, `agent:support-bot`).
+  Identity *binding* -- proving a caller is that principal -- is the host's
+  job (§18.4); CAL never sees or carries credentials.
+- `GRANT` writes a grant grain (OMS §12.6.2). `REVOKE` retracts the covering
+  grant grain(s) by supersession -- a full revoke retracts, a partial revoke
+  supersedes with the reduced grant -- so grant history is append-only and
+  nothing is deleted. GRANT/REVOKE are therefore **Tier-1-shaped writes
+  gated by Tier-3 authority**, not destructive operations.
+- **Who may GRANT:** a principal holding `admin` (on the target namespace),
+  or the owner session. Every `erase` grant is explicit -- if a future
+  revision defines role bundles, no bundle may include `erase`.
+  There is no `WITH GRANT OPTION`.
+- `SHOW GRANTS` is a read (sugar over `RECALL` of the PERMISSION relation
+  category); it requires only `read` on the authz namespace.
+
+#### 8.15.2 Fail-closed resolution
+
+A session principal's effective rights are the union of live (unsuperseded)
+grant grains naming it, intersected with the statement's target namespace.
+Unknown principal or empty result → Tier 0/1 only. A memory containing no
+grant grains confers nothing on anyone except the owner session.
+
+### 8.16 Governance statements (Tier 3 -- new in 1.3)
+
+The Recommendation lifecycle (OMS §8.12), expressible in the language whose
+data it governs.
+
+```sql
+RUN LOOP                                      -- incremental analysis pass
+RUN LOOP FULL WITH min_new(3), if_stale("6h") -- full sweep, gated
+APPROVE sha256:9c41... BECAUSE "matches our deploy policy"
+REJECT  sha256:9c41... BECAUSE "false positive - seasonal"
+APPLY   sha256:9c41... BECAUSE "approved in standup"
+ROLLBACK sha256:9c41... BECAUSE "regressed at the 30-day checkpoint"
+DESCRIBE loop        -- engine health   (read)
+DESCRIBE analyzers   -- registered analyzers (read)
+DESCRIBE outcomes    -- the Verify gate's measurements (read)
+DESCRIBE policy      -- the effective host policy (read)
+```
+
+#### 8.16.1 Semantics and gates
+
+- `BECAUSE` is REQUIRED on every lifecycle transition -- a missing reason is
+  a **parse error**, and hosts MUST additionally validate it non-empty at
+  execution. The reason lands in the transition's audit Observation
+  (OMS §8.12.1).
+- Verb mapping: `RUN LOOP` requires `loop.run`; `APPROVE`/`REJECT` require
+  `loop.review`; `APPLY`/`ROLLBACK` require `loop.apply`; a destructive
+  apply additionally requires the `delete`/`erase` verb its proposal needs
+  (two-key property).
+- **Self-approval MUST be refused** against the recommendation's creating
+  actor and, for a recommendation of LLM or external-command origin, against
+  the principal that triggered the run that authored it.
+- **Observer type MUST derive from the session principal's host record**
+  (§18.4) -- never from statement text. A statement cannot claim to be
+  human.
+- `RUN LOOP` carries no credentials and no model configuration -- analysis
+  backends are host-configured. `WITH` options are limited to gating knobs
+  (e.g. `min_new(n)`, `if_stale("6h")`).
+- Loop *policy* writes (auto-apply grants, analyzer deny-lists) are
+  permanently outside CAL: the policy is what gates these statements, and a
+  language able to edit its own gate would be self-licensing.
+- Governance statements are refused inside `BATCH`, saved-query bodies, and
+  `proposal_cal` (§8.14.3) -- no one-round-trip approve-and-apply macro, and
+  no recommendation whose payload approves other recommendations.
 
 ---
 
@@ -2391,6 +2614,35 @@ CAL String (ADD, SUPERSEDE, or REVERT)
 
 The namespace is ALWAYS taken from the token, never from the query. Implementations MUST overwrite any namespace specified in the CAL string with the token's namespace.
 
+### 18.4 Principal-Bound Sessions (Tier 2/3 -- new in 1.3)
+
+Tier-2 and Tier-3 execution requires a **principal-bound session**: the host
+authenticates a caller, resolves it to a principal name, and every statement
+in the session executes *as* that principal.
+
+- **The credential/policy split.** The host's credential store maps secrets
+  (tokens, passwords, OS identity) to principal *names*; the memory's grant
+  grains (OMS §12.6) map principal names to *rights*. Credentials MUST NOT
+  be carried in grains, in CAL statements, or in the memory file in any
+  form. A CAL statement can name a principal (`GRANT ... TO agent:x`); it
+  can never mint, present, or reveal a credential.
+- **The boundary rule.** Anything that needs a filesystem path, a
+  credential, or a process to exist is a host operation; everything that
+  acts on grains in an open memory is CAL. Hosts MUST NOT extend CAL past
+  this boundary.
+- **Observer class.** Each principal's host record carries its observer
+  class (`human` or an agent class per OMS §24); audit grains take
+  `observer_type` from that record, never from statement text.
+- **Owner sessions.** A host MAY designate a local session as *owner* (OMS
+  §12.6.4) -- the implicit superuser of the memory it opens, exempt from
+  grant lookup. This preserves the single-operator experience: a memory
+  with no grant grains is fully usable by its owner and confers nothing on
+  anyone else.
+- **Fail-closed.** An unauthenticated or unknown caller where a credential
+  map is configured resolves to an anonymous principal with at most `read`;
+  where no authorization model exists at all, Tier 2/3 statements MUST be
+  refused (`CAL-E120`).
+
 ---
 
 ## 19. Policy Integration
@@ -2411,7 +2663,7 @@ CAL queries execute through the same read path as all other interfaces. No CAL s
 
 - **Art. 15 (Right of Access):** CAL enables DSAR via `RECALL WHERE user_id = "alice" COUNT`
 - **Art. 16 (Right to Rectification):** CAL SUPERSEDE enables correction of inaccurate personal data.
-- **Art. 17 (Right to Erasure):** Excluded at grammar level. Erasure only via implementation-specific APIs.
+- **Art. 17 (Right to Erasure):** Expressible in-language since 1.3 -- `FORGET SUBJECT <id> BECAUSE "..."` (Tier 2, `erase` verb, audited, one-way; §8.14). Hosts without Tier 2 continue to serve erasure via implementation-specific APIs.
 - **Art. 20 (Data Portability):** CAL can serve as query interface for exports.
 - **Art. 25 (By Design):** Grammar-level safety qualifies as "by design" protection.
 
@@ -2496,6 +2748,24 @@ Every CAL execution MUST produce an audit entry.
 | `tier` | integer | 1 |
 | `duration_ms` | integer | Execution time |
 
+**Tier 2 (Destroy) and Tier 3 (Control) -- new in 1.3:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `query_hash` | string | SHA-256 of normalized CAL string |
+| `namespace` | string | Effective namespace |
+| `principal` | string | The session principal (§18.4) -- not pseudonymized; accountability requires the real name |
+| `operation` | string | `"forget"`, `"forget_subject"`, `"purge"`, `"grant"`, `"revoke"`, `"approve"`, `"reject"`, `"apply"`, `"rollback"`, `"run_loop"` |
+| `target` | string | Hash, subject identity, age window, or `principal/verbs/ns` for DCL |
+| `reason` | string? | The `BECAUSE` text (absent only on bare `FORGET <hash>`) |
+| `audit_grain` | string | Content address of the in-memory audit Observation (§8.14.4, OMS §8.12.1) |
+| `tier` | integer | 2 or 3 |
+| `duration_ms` | integer | Execution time |
+
+Unlike Tier 0/1 audit entries -- host-side logs -- Tier 2/3 executions
+additionally write their audit **into the memory itself** as an Observation
+grain (§8.14.4, §8.16.1), so accountability replicates with the file.
+
 **Streaming audit fields (additional):**
 
 | Field | Type | Description |
@@ -2544,6 +2814,7 @@ See [Appendix C](#appendix-c-error-code-registry) for the complete registry. Err
 | CAL-E085 -- CAL-E096 | Template | 12 |
 | CAL-E100 | Version | 1 |
 | CAL-E110, CAL-E113 | Multi-Format | 2 |
+| CAL-E120 -- CAL-E125 | Authorization (Tier 2/3, new in 1.3) | 6 |
 
 ### 22.3 Warning Codes
 
@@ -2643,10 +2914,30 @@ Everything in Evolve, plus:
 - `DESCRIBE templates`
 - WebSocket transport for streaming
 
-Implementations MUST declare conformance:
+### Tier modules (MAY implement -- new in 1.3)
+
+Orthogonal to Levels 1--4, the Tier 2/3 statement families are optional
+**modules**. Implementing one means implementing it whole:
+
+- **Destroy (Tier 2):** `FORGET <hash>`, `FORGET SUBJECT`, `PURGE OLDER
+  THAN`; an authorization model (host-defined suffices); the audit
+  Observation (§8.14.4); error codes CAL-E120--E125. Tier 2 without Tier 3
+  is legal.
+- **Control (Tier 3):** `GRANT`/`REVOKE`/`SHOW GRANTS`/`DESCRIBE PRINCIPAL`
+  over in-memory grant grains (OMS §12.6); principal-bound sessions
+  (§18.4); the governance statements (§8.16) where the host has a
+  recommendation engine. Implies the grant model Tier 2 consumes.
+
+A Tier-0/1 implementation is not diminished by declining both modules --
+**tiers gate operations, not portability** (§2.2), and conformance claims
+are per-tier.
+
+Implementations MUST declare conformance, including their tiers:
 ```json
-{"cal_conformance": "extended", "cal_version": "1.0"}
+{"cal_conformance": "extended", "cal_version": "1.3", "cal_tiers": [0, 1]}
 ```
+
+`DESCRIBE capabilities` MUST report the same tier list.
 
 ---
 
@@ -2871,6 +3162,17 @@ All error codes use the `CAL-E` prefix.
 | CAL-E110 | Too many formats in multi-format list (maximum 5) |
 | CAL-E113 | Duplicate format key in multi-format list (alias or canonical name collision) |
 
+### Authorization Errors (CAL-E120 -- CAL-E125, new in 1.3)
+
+| Code | Description |
+|------|-------------|
+| CAL-E120 | TierNotSupported — the host does not implement this statement's tier (or has no authorization model for Tier 2/3) |
+| CAL-E121 | NotAuthorized — the session principal lacks the statement's verb on the target namespace. The message SHOULD name the missing verb, the resource, and the `GRANT` statement that would confer it |
+| CAL-E122 | UnknownPrincipal — the named or session principal does not resolve |
+| CAL-E123 | SelfApproval — the reviewing principal created, or triggered the run that authored, this recommendation |
+| CAL-E124 | ContextRefused — Tier 2/3 statement inside `BATCH`, a saved-query body, or `proposal_cal` where forbidden (§8.14.3) |
+| CAL-E125 | ReasonRequired — a required `BECAUSE` reason is missing or empty at execution |
+
 ### Shortcut and Grain Type Errors (CAL-E060 -- CAL-E066)
 
 | Code | Description |
@@ -2959,7 +3261,10 @@ EXISTS, HISTORY, DESCRIBE, BATCH, COALESCE,
 ABOUT, RECENT, SINCE, LIKE, MY, CONTRADICTIONS, AS,
 FOR, FROM, BUDGET, PRIORITY, FORMAT,
 LET, THREAD, DIFF,
-ADD, SUPERSEDE, REVERT, SET, REASON,
+ADD, SUPERSEDE, REVERT, SET, REASON, BECAUSE,
+FORGET, PURGE, SUBJECT, OLDER, THAN, TYPE,
+GRANT, REVOKE, ON, TO, SHOW, GRANTS, PRINCIPAL,
+APPROVE, REJECT, APPLY, ROLLBACK, RUN, LOOP, FULL,
 STREAM, TEMPLATE, DEFINE, UNDEFINE, EXTENDS,
 HEADER, ELEMENT, ELEMENT_SUMMARY, ELEMENT_OMIT, SOURCE_BREAK, FOOTER,
 PREFERENCE, KNOWLEDGE, PERMISSION, INTERACTION, AGENCY, LIFECYCLE, OBSERVATION,
@@ -2976,7 +3281,8 @@ DIVERSITY, MMR, THRESHOLD, RERANK, PROVENANCE,
 SUPERSEDED, EXPLANATION, SCORE_BREAKDOWN,
 CONSISTENCY, EVENTUAL, BOUNDED, LINEARIZABLE,
 CACHE, PIN, UNPIN, MERGE, LANG,
-CHUNK, PAUSE, RESUME, CANCEL
+CHUNK, PAUSE, RESUME, CANCEL,
+ROLE                                        -- DEFINE ROLE, deferred (§3.2)
 ```
 
 ---
@@ -3076,14 +3382,15 @@ CHUNK, PAUSE, RESUME, CANCEL
 
 | Version | Date | Change |
 |---------|------|--------|
+| 1.3-draft | 2026-08-10 | **The pillar changes, on purpose and in the open.** 1.0--1.2 promised "non-destructive by grammar; no unsafe mode." The promise was true and had a hidden cost: real deployments still needed erasure -- GDPR, retention -- so destruction happened anyway, outside the language, ungoverned by any spec. Exiling destruction never prevented it; it only prevented *specifying* it. 1.3 brings it inside, where grammar bounds its shape (whole grains by hash, identity, or age -- never a predicate, never a key, no history rewrite, no `UNFORGET`), grants gate it per principal, and the audit trail sees it (a mandatory in-memory audit Observation per Tier-2 execution). Adds the four-tier model (Core/Evolve/Destroy/Control; tiers gate operations, not portability -- §2.2), Tier 2 statements `FORGET <hash>`/`FORGET SUBJECT`/`PURGE OLDER THAN` (§8.14), Tier 3 DCL `GRANT`/`REVOKE`/`SHOW GRANTS`/`DESCRIBE PRINCIPAL` over in-memory grant grains (§8.15, OMS §12.6), Tier 3 governance statements `APPROVE`/`REJECT`/`APPLY`/`ROLLBACK`/`RUN LOOP` + `DESCRIBE loop`-family (§8.16), principal-bound sessions and the credential/policy split (§18.4), authorization error codes CAL-E120--E125, and the `cal_tiers` conformance declaration. `DEFINE ROLE` reserved, deferred. Every 1.0--1.2 document remains valid Tier-0/1 CAL; a session without grants is exactly the language those releases promised -- the floor, not the ceiling. |
 | 1.2 | 2026-08-03 | As part of the OMS v1.5 release, adds the **Recommendation** grain type (`0x0C`) to the closed query set: `RECALL recommendations` with a type-specific field set (`target_ref`, `analyzer`, `severity`, `dedup_key`, `rec_status`), `<recommendation>` content projection, TOON columns, `recommendation_field` grammar production, and the type in `grain_type_plural`/`grain_type_singular`, `DESCRIBE`, and the JSON `valid_values` enum. Recommendation is **query-only** — it is engine-emitted and lifecycle-gated, so it is deliberately absent from the CAL-addable set (`ADD`/`SUPERSEDE SET` never create or transition a recommendation). Also adds the **`ELEMENT` shorthand** for custom templates (Section 10.6.1): `DEFINE TEMPLATE <name> AS "<text>"` and `FORMAT TEMPLATE "<text>"`, both defined by equivalence to an `ELEMENT` section, plus the `template_shorthand` production and `"TEMPLATE" , string_literal` in `format_spec`. This also corrects two 1.1 defects in the same examples (Sections 10.1.1, 14.2.1, 27): the `TEMPLATE "..."` form they use was not admitted by the Section 4 grammar, and they interpolated bare `{{subject}}`/`{{object}}` rather than the `grain.` namespace that Section 10.5 defines and Section 10.8 closes. Backward-compatible. |
 | 1.1 | 2026-03-05 | Multi-format output: FORMAT and AS clauses accept bracketed format lists (`FORMAT [markdown, json]`). Single query execution produces multiple renderings. New Section 10.1.1 (syntax and rules), Section 14.2.1 (multi-format response shape), error code CAL-E110. Backward-compatible — single-format syntax unchanged. As part of the OMS v1.4 release, also adds the Skill grain type (`0x0B`) to the closed query set (`RECALL skills` / `ADD skill`, type-specific field set, `<skill>` projection, TOON columns, `mg:capable_of` in the `AGENCY` shortcut) and corrects `belief`/`action` literals the rename left behind (`grain_type_plural`, `RECALL MY`, TOON tables, `DESCRIBE` listing, `CAL-E051`). |
 | 1.0 | 2026-03-03 | Initial CAL specification. 12-variant statement model. Tier 0 (RECALL, ASSEMBLE, SetOp, EXISTS, HISTORY, EXPLAIN, DESCRIBE, BATCH, COALESCE) + Tier 1 (ADD, SUPERSEDE, REVERT). ASSEMBLE with budget, priority, format, streaming. Semantic shortcuts (ABOUT, RECENT, SINCE, LIKE, MY, CONTRADICTIONS, BETWEEN). LET bindings. Custom FORMAT templates (Mustache-subset). Grain-type-specific queryable fields for all 10 OMS types. mg: relation vocabulary with category shortcuts. Domain profile querying. Dual wire format (text/cal + application/json+cal). Internationalization (Unicode NFC, cross-lingual search, bidi safety). Streaming protocol (SSE, NDJSON, WebSocket). THREAD shorthand. HISTORY AS OF and DIFF. Non-destructive safety model. Content Projection Model with flat semantic output (Section 10.3-10.4). PROJECT clause for custom field surfacing. Per-grain-type content projection rules with humanize() and time humanization. ELEMENT/ELEMENT_SUMMARY/SOURCE_BREAK template sections for flat semantic rendering. TOON (Token-Oriented Object Notation) format support — `toon` as a first-class FORMAT/AS preset (Section 10.9): tabular CSV rendering for uniform RECALL results, grouped-section rendering for ASSEMBLE results, per-grain-type column sets at each disclosure level, PROJECT integration, STREAM compatibility, auto-TOON budget-pressure hint (CAL-W005). |
 
 ---
 
-**Document Status:** This is the CAL (Context Assembly Language) Specification v1.2. It defines a non-destructive, deterministic, LLM-native context assembly and evolution language for OMS-compliant memory databases. CAL is part of the Open Memory Specification (OMS) v1.5 — see [SPECIFICATION.md](./SPECIFICATION.md).
+**Document Status:** This is the CAL (Context Assembly Language) Specification v1.3, **draft for comment**. It defines a deterministic, LLM-native context assembly, evolution, destruction, and control language for OMS-compliant memory databases — append-only by construction for evolution, authorization-gated for destruction and control. CAL is part of the Open Memory Specification (OMS) v1.6 draft — see [SPECIFICATION.md](./SPECIFICATION.md).
 
-**Last Updated:** 2026-08-03
+**Last Updated:** 2026-08-10
 **License:** This specification is offered under the Open Web Foundation Final Specification Agreement (OWFa 1.0)
 **Copyright:** Public Domain (CC0 1.0 Universal)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,11 @@ Open a pull request directly with:
 
 ### Pull Request Requirements
 
-- [ ] Changes are in `oms-specification.md`
+- [ ] Changes are in the right document — `SPECIFICATION.md` (the `.mg` format
+      and store conventions), `CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md`
+      (the query language), or
+      `SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md` (the render format) —
+      and `CHANGELOG.md` records them
 - [ ] New normative requirements use correct RFC 2119 language (MUST/SHOULD/MAY)
 - [ ] Test vectors are updated if the binary format changes
 - [ ] Conformance level impact is noted if applicable

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Memory Specification (OMS)
 
-**Version:** 1.5 | **Status:** Standards Track | **License:** CC0 1.0 Universal (Public Domain)
+**Version:** 1.6-draft (1.5 released) | **Status:** Standards Track — 1.6/CAL 1.3 open for comment | **License:** CC0 1.0 Universal (Public Domain)
 
 Backed by [areev.ai](https://areev.ai).
 
@@ -9,7 +9,7 @@ OMS is an open standard for portable, auditable, and interoperable agent memory.
 | Layer | Spec | Role |
 |-------|------|------|
 | **Storage** | OMS — Open Memory Specification | Binary `.mg` container: how grains are encoded, hashed, signed, and stored |
-| **Query** | CAL — Context Assembly Language | Non-destructive language for recalling and assembling agent context |
+| **Query** | CAL — Context Assembly Language | Language for recalling, assembling, and evolving agent context — append-only by construction; destruction and access control authorization-gated (1.3 draft) |
 | **Output** | SML — Semantic Markup Language | Tag-based LLM context format produced by CAL `ASSEMBLE` |
 
 ---

--- a/SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md
+++ b/SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md
@@ -1,6 +1,6 @@
 # SML (Semantic Markup Language) Specification v1.1
 
-**Status:** Standards Track | **Date:** 2026-08-03 | **Version:** 1.1 | **Classification:** Experimental
+**Status:** Standards Track | **Date:** 2026-08-19 | **Version:** 1.2 | **Classification:** Experimental
 **Part of:** [Open Memory Specification (OMS) v1.5](./SPECIFICATION.md)
 
 ---
@@ -10,7 +10,7 @@
 - [Abstract](#abstract)
 1. [What is SML?](#1-what-is-sml)
 2. [Structural Rules](#2-structural-rules)
-3. [Comprehensive Example — All 12 Grain Types](#3-comprehensive-example--all-12-grain-types)
+3. [Comprehensive Example — All 13 Grain Types](#3-comprehensive-example--all-13-grain-types)
 4. [Progressive Disclosure](#4-progressive-disclosure)
 - [Appendix A: Relationship to CAL](#appendix-a-relationship-to-cal)
 - [Appendix B: Version History](#appendix-b-version-history)
@@ -58,7 +58,7 @@ The formatted output uses a **flat, semantic structure**:
 
 ---
 
-## 3. Comprehensive Example — All 12 Grain Types
+## 3. Comprehensive Example — All 13 Grain Types
 
 The following example shows a single assembled context covering every grain type. The scenario: an agent helping alice prepare her Q1 engineering review.
 
@@ -87,7 +87,7 @@ The following example shows a single assembled context covering every grain type
 
   <state context="q1_review_prep">outlining slides: 1. headline metrics  2. incident retrospective  3. velocity trend  4. Q2 goals</state>
 
-  <workflow trigger="review_prep_requested">retrieve_metrics -> identify_narrative -> draft_outline -> populate_data -> send_for_review</workflow>
+  <workflow name="review prep">retrieve_metrics -> identify_narrative -> draft_outline -> populate_data -> send_for_review</workflow>
 
   <consensus threshold="3" count="4">Q1 deployment frequency improved 18% over Q4 2025</consensus>
 
@@ -96,6 +96,8 @@ The following example shows a single assembled context covering every grain type
   <skill name="metrics_review" proficiency="0.82" domain="software">summarise quarterly engineering metrics and surface the reliability narrative</skill>
 
   <recommendation target="entity:alice/velocity" severity="low">consolidate 2 duplicate "week 8 velocity" observations into one</recommendation>
+
+  <trigger kind="polling" scope="mailbox:accounts@example.com">poll the accounting mailbox every 2 minutes for invoices</trigger>
 
 </context>
 ```
@@ -133,6 +135,7 @@ See the [CAL specification](./CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md) fo
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 1.2 | 2026-08-19 | Adds the `<trigger>` element for the Trigger grain type (`0x0D`), introduced in OMS v1.6 — rendering what a standing rule watches, with `kind` and `scope` attributes — and extends the comprehensive example to all 13 grain types. Additive: every SML 1.1 document remains a valid SML 1.2 document. |
 | 1.1 | 2026-08-03 | Adds the `<recommendation>` element for the Recommendation grain type (`0x0C`), introduced in OMS v1.5 — rendering the proposal summary with `target`, `severity` and `analyzer` attributes — and extends the comprehensive example to all 12 grain types. Additive: every SML 1.0 document remains a valid SML 1.1 document. |
 | 1.0 | 2026-03-03 | Initial standalone specification, decoupled from CAL. Eleven grain-type elements, structural rules, and progressive disclosure levels. |
 

--- a/SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md
+++ b/SEMANTIC-MARKUP-LANGUAGE-SML-SPECIFICATION.md
@@ -143,6 +143,6 @@ See the [CAL specification](./CONTEXT-ASSEMBLY-LANGUAGE-CAL-SPECIFICATION.md) fo
 
 **Document Status:** This is the SML (Semantic Markup Language) Specification v1.1. SML is part of the Open Memory Specification (OMS) v1.5 — see [SPECIFICATION.md](./SPECIFICATION.md).
 
-**Last Updated:** 2026-08-03
+**Last Updated:** 2026-08-19
 **License:** This specification is offered under the Open Web Foundation Final Specification Agreement (OWFa 1.0)
 **Copyright:** Public Domain (CC0 1.0 Universal)

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1130,7 +1130,7 @@ Where a Reasoning grain (§8.8) records *why the agent believes something* and a
 
 **Required fields:**
 - `type` = "recommendation"
-- `target_ref` (string) — the change target as `<scheme>:<opaque>`. Standard schemes: `grain:sha256:<hash>` (a specific grain), `entity:<namespace>/<subject>` (an entity), `query:<namespace>/<name>` (a saved query), `template:<namespace>/<name>` (a template), `doc:<host-id>` (a host document, e.g. `doc:claude.md`), `host:<opaque>` (an opaque host object). The scheme is the target-kind discriminator; the scheme set is open for host-defined targets.
+- `target_ref` (string) — the change target as `<scheme>:<opaque>`. Standard schemes: `grain:sha256:<hash>` (a specific grain), `entity:<namespace>/<subject>` (an entity), `query:<namespace>/<name>` (a saved query, CAL §8.18), `template:<namespace>/<name>` (a template, CAL §10.6), `doc:<host-id>` (a host document, e.g. `doc:claude.md`), `host:<opaque>` (an opaque host object). The scheme is the target-kind discriminator; the scheme set is open for host-defined targets.
 - `analyzer` (map) — the producing logic: `{id: string, params?: map}`, where `id` is a versioned identifier `publisher.name/major` (e.g. `"waiser.duplicate_sweep/1"`) and `params` is an optional snapshot of the parameters it ran with. Full "why" provenance without a second grain.
 - `summary` (map) — a deterministic, template-rendered description: `{template_id: string, args: map}`. An analyzer MUST NOT store free prose here; the human-readable string is produced by rendering `template_id` with `args`, so summaries stay reproducible and translatable.
 - `dedup_key` (string) — the recommendation's stable proposal identity, computed (never author-chosen) per normative rule 5. Two recommendations with the same `dedup_key` are the same proposal; a supersession chain (evidence refresh, a growing cluster) shares one `dedup_key` across all of its content addresses.
@@ -3326,6 +3326,77 @@ OMS does not define a formal store API. However, implementations that expose a p
 
 Stores SHOULD implement `supersede` as a distinct operation rather than exposing raw `put` + index mutation separately. Supersession is the most error-prone operation (invalidation policy checks, derivation DAG traversal for `scope: "subtree"`, atomic index update) and deserves a dedicated, well-tested code path.
 
+### 28.4.1 Host metadata table (new in 1.6)
+
+Every operation in §28.4 addresses a grain. A memory also carries a small
+amount of state that is **not** memory: declarations about the file itself, and
+definitions an operator authored so they travel with it. Sections 10.5.1,
+10.5.2 and §27.8 already refer to "reserved store-metadata prefixes" without
+this specification saying what a store-metadata row *is*. This section defines
+it.
+
+A conforming store that offers a programmatic interface SHOULD expose a
+**metadata table**: a flat, string-keyed, string-valued map stored in the
+memory alongside its grains.
+
+| Operation | Signature | Description |
+|---|---|---|
+| `meta_get` | `(key) → value \| not_found` | Read one metadata row |
+| `meta_put` | `(key, value) → void \| error` | Create or replace one row. Replacing a row overwrites it; there is no metadata history |
+| `meta_delete` | `(key) → void \| error` | Remove one row |
+| `meta_scan` | `(key_prefix) → [(key, value)]` | Enumerate rows under a prefix |
+
+**Normative rules:**
+
+1. **Metadata rows are not grains.** They are not content-addressed, they do
+   not appear in `query`/`search` results, they do not supersede, they carry no
+   provenance, and writing one does not change any content address. An
+   implementation MUST NOT surface metadata rows through a grain read.
+2. **Rows are per-memory.** The isolation unit for metadata is the memory that
+   holds it, exactly as for grains.
+3. **The prefix registry below is closed to implementations.** A prefix listed
+   there carries the stated semantics; an implementation MUST NOT repurpose
+   one. Unlisted prefixes are available for host use and need no registration,
+   but an implementation MUST preserve rows it does not recognize rather than
+   dropping them on rewrite -- a memory is routinely opened by more than one
+   implementation and by more than one version of the same one.
+4. **Replication is per-prefix, and the default is "does not replicate".** A
+   metadata row replicates only where its prefix says so. The distinction the
+   registry encodes throughout is: **what a definition or declaration *is* may
+   replicate; a record of where one host got to MUST NOT.** A peer receiving
+   another host's cursor, lock, or usage counter would act on a position it
+   never occupied.
+5. **Point-in-time restore skips metadata**, and MUST report that it did. A
+   restore reconstructs grain history; it is not an instruction to revert an
+   operator's configuration to what it was on the restore date.
+6. **An unloadable row is skipped, warned, and kept.** A row written by a newer
+   revision, or one that no longer satisfies a since-tightened limit, MUST NOT
+   fail the open. The implementation skips it, reports it through whatever channel
+   it reports open-time warnings on, and leaves it in the file so an implementation that
+   can read it still can. Overwriting the row is what loses it.
+
+**Reserved prefix registry:**
+
+| Prefix | Holds | Replicates | Defined in |
+|---|---|---|---|
+| `qry:<name>` | A saved query definition | Yes — latest-wins on the definition's update time | CAL §8.18 |
+| `tpl:<name>` | A custom output template definition | Yes — latest-wins on the definition's update time | CAL §10.6 |
+| `retention:<namespace>` | A declarative retention policy | Yes — write-if-absent | §10.5.1 (same rule) |
+| `anon:<namespace>` | A pseudonymized-egress policy | Yes — write-if-absent | §10.5.1 |
+| `vault:<namespace>:<placeholder>` | A sealed placeholder→value mapping | **Never, in either direction** | §10.5.2 |
+| `trg:<trigger>` | Per-host trigger evaluation state (baselines, cursors, dedup keys) | **No** — host-local by §27.8 | §27.8 |
+
+Rows that record *usage* rather than definition — a last-execution stamp on a
+saved query, a last-evaluated stamp on a trigger — MUST NOT replicate even when
+they ride a replicating prefix, and an incoming update MUST leave the local
+value intact.
+
+**File-truth rows.** A store MAY also keep rows describing capabilities the
+file was written with (whether text is indexed, whether entity relations are
+extracted, embedding provenance). These are infrastructure truths about one
+copy, and they MUST NOT replicate: a peer that cannot build a text index does
+not acquire one by importing a bundle that says it has one.
+
 ### 28.5 Agent Capability Convention
 
 Agents that participate in multi-agent systems SHOULD advertise their capabilities by writing a Fact grain with the `mg:has_capability` relation to the `"agent:identity"` namespace. This grain serves as the OMS equivalent of an A2A Agent Card or MCP server capability declaration.
@@ -3495,6 +3566,10 @@ CAL extends the store operations defined in §28.4 with a structured query langu
 | `query`/`search` + `get_batch` + compose | `ASSEMBLE … FROM … BUDGET <n> TOKENS` |
 | introspection | `DESCRIBE <type>` |
 | `delete` (compliance erasure) | `FORGET <hash>` / `FORGET SUBJECT` / `PURGE OLDER THAN` (Tier 2, authorization-gated, audited — CAL §8.14; no CAL equivalent on Tier-0/1 hosts) |
+| `meta_put` / `meta_delete` (§28.4.1) | `DEFINE QUERY` / `DROP QUERY` (CAL §8.18), `DEFINE TEMPLATE` / `DROP TEMPLATE` (CAL §10.6) — definitions, not grains |
+| `meta_get` + the body's own operations | `RUN "<name>"` (CAL §8.18.3) |
+| `meta_scan` (§28.4.1) | `DESCRIBE QUERIES` / `DESCRIBE TEMPLATES` |
+| `put_blob` / `get_blob` (§28.4) | No CAL equivalent — CAL addresses grains; blob bytes reach a caller through the host API (§7.1) |
 
 **SML output format:**
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -3529,6 +3529,69 @@ the two are indistinguishable by address — that is what content addressing
 means. Implementations SHOULD document this window rather than describe
 reclamation as unconditional.
 
+### 28.4.4 Subject reachability (new in 1.6)
+
+CAL §8.14 defines the erasure selector (`FORGET SUBJECT "<id>"`) and §8.14 its
+read-only mirror (`REPORT SUBJECT`), and prior revisions said what those
+statements *mean* without ever saying what they must **reach**. That gap is not
+academic. It was found in a conforming implementation as a silent
+under-erasure:
+
+> A grain carrying a `subject` but asserting no relation or object — an Event
+> *about* a person, a message, an entity — reached no structural index at all,
+> because the index required a complete triple. Both `FORGET SUBJECT` and
+> `REPORT SUBJECT` select through that index. So the identity's own transcript
+> survived an erasure **that reported success**, and went undisclosed in a DSAR
+> **that reported completeness**. Nothing in this specification made that
+> non-conformant.
+
+An implementation must not be able to pass conformance while silently
+under-erasing. The following are therefore normative.
+
+1. **Reachability is a property of the identity, not of grain shape.** Subject
+   selection MUST reach **every** grain whose `subject` matches the identity,
+   regardless of grain type and regardless of whether the grain also carries a
+   relation or an object. An implementation whose index requires a complete
+   triple MUST index subject-only grains by some other means rather than
+   omitting them.
+2. **Reach extends to the identity's derived keys.** Selection MUST also reach
+   grains that carry the identity in the `object` position (over-reach is the
+   safe direction for erasure), grains whose `session_id` or `run_id` **is** the
+   identity or is a partition-style key carrying it as a boundary-guarded
+   prefix, and — where the host offers text-mention matching — grains whose
+   indexed text mentions it.
+3. **Erasure and disclosure MUST share one selector.** The set a DSAR discloses
+   and the set an erasure removes MUST be computed by the same code path over
+   the same indexes. Two selectors drift, and a drift in this pair means either
+   disclosing what was not erased or erasing what was never disclosed. This is
+   the property that lets an implementation answer "what would you delete?"
+   honestly before deleting anything.
+4. **A selector that cannot reach a class of grains MUST NOT report success.**
+   An erasure or report whose scope is known-incomplete MUST surface that —
+   whether because a text index is absent, an index version predates a
+   reachability fix, or a grain class is not indexed at all. Reporting a count
+   without reporting the limitation is the failure mode this section exists to
+   forbid.
+5. **A reachability fix MUST heal existing memories.** Grains written before the
+   fix are already in the file and are exactly the ones at risk, so an
+   implementation MUST rebuild the affected index (an index-version stamp
+   checked at open is sufficient) rather than only indexing correctly from the
+   fix forward. A rebuild MUST reconstruct supersession state, so healing
+   neither duplicates a grain nor resurrects a superseded one.
+6. **Residual limits MUST be documented, not implied.** Text-mention matching
+   reaches exactly what the text index reaches; identifiers the tokenizer splits
+   differently are matched only through structured references; an identifier
+   appearing only inside an opaque body field is not reachable by any structural
+   selector. Implementations MUST state which of these apply rather than
+   describe erasure as exhaustive.
+
+**Conformance.** An implementation claiming subject erasure or subject
+disclosure MUST include, in its conformance suite, a case that stores a grain
+carrying **only** a subject — no relation, no object — and asserts that it
+appears in the subject report and is gone after the subject erasure. The case
+exists specifically because that grain shape is the one a triple-shaped index
+loses, and because both operations reported success while failing on it.
+
 ### 28.5 Agent Capability Convention
 
 Agents that participate in multi-agent systems SHOULD advertise their capabilities by writing a Fact grain with the `mg:has_capability` relation to the `"agent:identity"` namespace. This grain serves as the OMS equivalent of an A2A Agent Card or MCP server capability declaration.

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1338,6 +1338,70 @@ In distributed systems:
 
 ---
 
+### 10.5 Pseudonymized Egress (new in 1.6)
+
+Selective disclosure (Sections 10.1-10.4) hides fields from a *receiving
+store*. Pseudonymized egress addresses the other disclosure channel: the
+**external model**. When context leaves for an LLM, sensitive values are
+replaced with category-typed placeholder tokens (`[PERSON_1]`,
+`[EMAIL_2]`); the placeholder-to-value mapping stays with the holder, and
+the model's response is rehydrated by exact token replacement before the
+caller sees it. This is **pseudonymization, not anonymization** -- an
+implementation MUST NOT describe it otherwise: with the mapping retained,
+the egress stream remains personal data, and rich content stays linkable
+under auxiliary-knowledge attacks regardless of identifier removal.
+
+#### 10.5.1 The `anon:<namespace>` policy (reserved store-metadata prefix)
+
+A per-namespace JSON policy declaring mode (`off | egress | ingress | both
+| audit`), category-to-action mappings (`pseudonym | mask | redact |
+generalize:<bucket> | allow`), detector demands, pseudonym scope, and
+placeholder template. Conformance requirements:
+
+- **Replication is write-if-absent.** Like retention declarations, a sync
+  MUST NOT silently swap a live local policy, and an applied row MUST take
+  effect on the live handle rather than at the next open.
+- **An unreadable policy row fails reads closed.** A policy the
+  implementation cannot parse MUST NOT silently mean "no policy": reads of
+  covered namespaces refuse until the row is repaired, while policy writes
+  keep working so it can be.
+- **Declaring a policy stamps the file's minimum-reader version**, so an
+  older implementation is warned loudly at open that the file declares
+  protection it cannot honor.
+- Value-derived (cross-handle-stable) pseudonyms MUST be keyed from the
+  file's encryption key; an implementation MUST refuse such declarations
+  on an unencrypted file rather than degrade to unkeyed derivation.
+
+#### 10.5.2 The `vault:` prefix (reserved, never replicated)
+
+`vault:<namespace>:<placeholder>` rows persist the sealed
+placeholder-to-value mapping for flows that must rehydrate across
+processes. Conformance requirements are prohibitions:
+
+- The prefix is **reserved**; implementations MUST NOT repurpose it.
+- Vault rows **MUST NOT ride bundles or segments in either direction** --
+  export omits them and import refuses them. A re-identification table
+  travelling to a replica undoes the pseudonymization it serves.
+- Values MUST be sealed under a key derived from the file's encryption key
+  with its own domain separation, so destroying the file key destroys the
+  vault -- crypto-erasure reaches it by construction.
+- **Erasure reaches the vault**: subject erasure (CAL `FORGET SUBJECT`)
+  MUST also remove every vault row and live mapping entry whose plaintext
+  names the erased identity, and MUST treat a failure to do so as an
+  error, never best-effort.
+- Reverse lookup (reveal / CAL `REHYDRATE`) is a privileged act: gated on
+  a grant and recorded as a Tier-2 audit Observation naming value
+  *fingerprints*, never identities.
+
+#### 10.5.3 The `anonymized` response report
+
+When an egress policy is active, query responses carry an `anonymized`
+object beside the result: covered namespaces, whether a host-level floor
+forced coverage, and per-namespace mapping **ids**. The mappings
+themselves MUST NOT ride any response payload -- rehydration custody stays
+with the holding process. Consumers MUST treat the field's absence as
+"values are as stored", never as "values are safe".
+
 ## 11. File Format (.mg files)
 
 ### 11.1 Purpose

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -874,6 +874,20 @@ The `mg:` namespace is reserved for standard semantic relations. Applications de
 | `mg:depends_on` | Goal | Task dependency (distinct from `parent_goals` hierarchy) |
 | `mg:assigned_to` | Goal | Task assigned to agent for execution |
 | `mg:capable_of` | Skill | Learned skill with proficiency and strategies (§8.11; legacy Fact convention retained for back-compat) |
+| `mg:step_action:<node_id>` | Tool | Execution record linking a Tool grain to the Workflow node it ran (§8.4). **Parameterized** — see below |
+
+**Parameterized relations.** `mg:step_action:<node_id>` is the first standard
+relation whose full value is not a fixed string: the node identifier is part of
+it, so the vocabulary above lists a *prefix* rather than a member. It was used
+normatively in §8.4 from the revision that introduced it while appearing in no
+vocabulary list, which made a conformant validator warn (CAL-W001, "unknown
+`mg:` relation") on this specification's own relation.
+
+Validators MUST therefore match `mg:` relations against the vocabulary by
+**prefix where a row is marked parameterized**, and exact value otherwise.
+Implementations that index relations by exact value need a prefix scan to find
+these; that is a consequence of parameterizing a relation, and the reason no
+other standard relation does it.
 
 ### 8.1 Fact (type = 0x01)
 
@@ -4552,7 +4566,7 @@ content_address = sha256(blob).hex()
 
 ---
 
-**Document Status:** This is the v1.5 revision of the .mg format specification. It adds the dedicated **Recommendation** grain type (`0x0C`, §8.12) — a governed, auditable proposal to change memory or agent configuration, with a supersession-based content model and an audit-grain lifecycle — realized from the reserved range following the Skill (`0x0B`) precedent; byte values `0x01`–`0x0B` are unchanged, so existing content addresses remain valid. (The prior v1.4 revision renamed `belief`→`fact` (`0x01`) and `action`→`tool` (`0x05`), redesigned the Workflow grain as a directed graph, added the `embedding_text` common field, and added the Skill grain type (`0x0B`, §8.11).) Submitted as a standards track document for consideration as an IETF RFC and W3C standard. Community feedback is encouraged through issue tracking and discussion forums.
+**Document Status:** This is the **v1.6 draft** of the .mg format specification, open for comment. It adds the **Trigger** grain type (`0x0D`, §8.13) and its execution contract (§27.8), pseudonymized egress (§10.5), the authorization model (§12.6), the host metadata table (§28.4.1), the `cas:` URI scheme (§7.1.1) with blob operations and their erasure obligations (§28.4.2–§28.4.3), the subject-reachability conformance requirement (§28.4.4), and the `mail:` domain profile (Appendix A.8); it removes §27.6 and `Workflow.trigger`. (The prior v1.5 revision added the dedicated **Recommendation** grain type (`0x0C`, §8.12) — a governed, auditable proposal to change memory or agent configuration, with a supersession-based content model and an audit-grain lifecycle — realized from the reserved range following the Skill (`0x0B`) precedent.) Byte values `0x01`–`0x0C` are unchanged, so existing content addresses remain valid. (The v1.4 revision renamed `belief`→`fact` (`0x01`) and `action`→`tool` (`0x05`), redesigned the Workflow grain as a directed graph, added the `embedding_text` common field, and added the Skill grain type (`0x0B`, §8.11).) Submitted as a standards track document for consideration as an IETF RFC and W3C standard. Community feedback is encouraged through issue tracking and discussion forums.
 
-**Last Updated:** 2026-08-03
+**Last Updated:** 2026-08-19
 **License:** This document is offered under the Open Web Foundation Final Specification Agreement (OWFa 1.0)

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -744,6 +744,52 @@ Multi-modal content (images, audio, video, embeddings, sensor data) is reference
 | `checksum` | `ck` | string | RECOMMENDED | SHA-256 hash for integrity |
 | `metadata` | `md` | map | OPTIONAL | Modality-specific metadata |
 
+### 7.1.1 The `cas:` URI scheme (new in 1.6)
+
+`cas://sha256:<64-lowercase-hex>` addresses bytes held in a **content-addressed
+store** that the memory owns. Prior revisions used the scheme once, as an
+example URI in §7.1, and never defined it. This section does.
+
+```
+cas://sha256:a0864a70f3c1b9e2…      (exactly 64 lowercase hex characters)
+```
+
+**Normative rules:**
+
+1. **The address is the SHA-256 of the plaintext bytes.** Not of a stored,
+   compressed, or encrypted representation. A store that encrypts blobs at rest
+   MUST keep the address over the clear bytes, so the same content addresses
+   identically in an encrypted memory and a plaintext one. An address that
+   changed when a memory was encrypted would break every `content_refs` entry
+   pointing at it and would make `checksum` (§7.1) disagree with `uri` for no
+   semantic reason.
+2. **The address is a claim about the bytes, so a reader MUST check it.**
+   `get_blob` (§28.4) MUST verify the digest of the bytes it returns against the
+   address it was given and fail rather than return bytes that do not match.
+   Where blobs are sealed, the AEAD tag and the content address are independent
+   checks and an implementation SHOULD perform both — they fail on different
+   attacks.
+3. **Resolution is memory-local.** `cas://` names content in *this* memory's
+   store; it is not a network locator and MUST NOT be dereferenced by fetching a
+   URL. A grain that travels to a peer carries the address, and the peer
+   resolves it against its own store or reports it missing. Blobs do not
+   replicate implicitly with grains — an implementation that ships attachments
+   alongside a bundle MUST do so as an explicit part of that transfer.
+4. **A `cas://` reference is not a promise of presence.** Erasure (§28.4.3),
+   selective transfer, and partial imports all produce a memory that holds a
+   grain whose attachment is gone. Readers MUST treat a missing blob as an
+   expected outcome, not as corruption.
+5. **Malformed addresses fail closed.** An address that is not exactly
+   `cas://sha256:` followed by 64 hex characters MUST be rejected as invalid
+   input before any lookup. Addresses arrive from imported grains and from
+   callers; length-validating after slicing is how a truncated URI becomes a
+   panic.
+
+When `uri` is a `cas://` address, `checksum` (§7.1) is redundant with it: the
+address *is* the checksum. Implementations MAY populate both, and MUST reject
+the entry as malformed if they disagree.
+
+
 ### 7.2 Embedding Reference Schema
 
 ```json
@@ -3323,6 +3369,8 @@ OMS does not define a formal store API. However, implementations that expose a p
 | `delete` | `(content_address) → void \| error` | Compliance erasure (GDPR Art. 17, consent cascade, retention). MUST NOT be exposed as a general-purpose unauthenticated API; MAY be surfaced to authorized principals via CAL Tier 2 (`FORGET`/`PURGE`, CAL §8.14 — `delete`/`erase` verbs, §12.6), each execution writing an audit Observation. MUST check litigation holds (`invalidation_policy.mode: "hold"`) before deleting. **One-way:** additions roll back by retraction (supersession); a delete or erasure is final — no un-delete operation exists, and a host MUST NOT add one. |
 | `put_batch` | `(blob_bytes[]) → content_address[] \| error[]` | Batch ingest for consolidation, migration, and high-throughput scenarios |
 | `get_batch` | `(content_address[]) → grain[] \| not_found[]` | Batch retrieval for provenance chain traversal and context assembly |
+| `put_blob` | `(bytes) → cas_uri \| error` | Store multi-modal content in the memory's content-addressed store; returns its `cas://sha256:` address (§7.1.1). **Idempotent by construction** — the address is the content, so re-storing identical bytes returns the same address and writes nothing new |
+| `get_blob` | `(cas_uri) → bytes \| not_found \| error` | Fetch blob bytes, **verifying the digest against the address** before returning them (§7.1.1 rule 2) |
 
 Stores SHOULD implement `supersede` as a distinct operation rather than exposing raw `put` + index mutation separately. Supersession is the most error-prone operation (invalidation policy checks, derivation DAG traversal for `scope: "subtree"`, atomic index update) and deserves a dedicated, well-tested code path.
 
@@ -3420,6 +3468,66 @@ file was written with (whether text is indexed, whether entity relations are
 extracted, embedding provenance). These are infrastructure truths about one
 copy, and they MUST NOT replicate: a peer that cannot build a text index does
 not acquire one by importing a bundle that says it has one.
+
+### 28.4.2 Blob concurrency (new in 1.6)
+
+A blob is immutable and its address is its checksum. Those two properties
+together mean a blob read has **no consistency question to answer**, and a
+store SHOULD NOT impose one:
+
+- **Reads need no lock.** There is no version to be stale against, no partial
+  write to observe (a store MUST make blob writes atomic — write-then-rename or
+  the transactional equivalent — so a reader sees the whole blob or none of
+  it), and any corruption the absent lock could admit is caught by the digest
+  check that §7.1.1 already requires. This matters concretely on stores whose
+  memory lock is exclusive: a run holding a memory would otherwise starve the
+  very subprocess it spawned to process an attachment, for a lock protecting
+  nothing.
+- **Writes need no coordination.** Two writers storing identical bytes converge
+  by construction; two writers storing different bytes are writing to different
+  addresses.
+
+### 28.4.3 Blob lifecycle under erasure (new in 1.6)
+
+**A blob is in scope for erasure.** A subject's invoice PDF, voice recording, or
+scanned ID is personal data as surely as the grain that references it, and it is
+usually the *more* sensitive half. Erasing every grain that references it while
+leaving the bytes on disk satisfies no erasure obligation, and an implementation
+that reported such an operation as successful would be reporting an erasure it
+did not perform. This is the same severity class as the vault rule in §10.5.2,
+and it is normative for the same reason.
+
+1. **Subject erasure MUST reclaim sole-referenced attachments.** When erasure
+   (CAL `FORGET SUBJECT`, or the host equivalent) removes a set of grains, every
+   `cas://` address those grains referenced that **no surviving grain
+   references** MUST be destroyed in the same operation. An address still
+   referenced by a survivor MUST be kept: the blob is shared, and the surviving
+   reference is a legitimate claim on it.
+2. **Reclamation MUST be targeted, never a store-wide sweep.** The candidate set
+   is the erased grains' own references — not a census of every blob in the
+   store. A whole-store mark-and-sweep races concurrent writes: content uploaded
+   but not yet referenced by its grain looks unreferenced to a census taken
+   between the two, and collecting it destroys an unrelated caller's data. A
+   general garbage collection over blobs MAY be offered as a separate,
+   explicitly-invoked operation, and one that scans the whole store MUST require
+   quiescent writers.
+3. **The surviving-reference check MUST run under the same serialization as the
+   erasure.** Checking outside it reintroduces exactly the race rule 2 avoids.
+4. **The erasure report MUST state how many blobs it reclaimed**, as a distinct
+   count from grains erased. An operator confirming an Art. 17 request needs to
+   see that the attachments went, and a zero where attachments existed is the
+   signal that they did not.
+5. **Crypto-erasure MUST reach blobs.** Where a memory is encrypted, blob
+   contents MUST be sealed under a key derived from the memory's key, so
+   destroying that key destroys the attachments with the grains. A store that
+   encrypts its database while leaving attachments in the clear beside it has
+   encrypted the index and published the documents.
+
+**Residual limit, stated rather than implied.** Byte-identical content uploaded
+by a concurrent writer in the instant an erasure runs may survive it, because
+the two are indistinguishable by address — that is what content addressing
+means. Implementations SHOULD document this window rather than describe
+reclamation as unconditional.
 
 ### 28.5 Agent Capability Convention
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -707,7 +707,7 @@ When a Goal or Fact grain uses the `mg:delegates_to` relation, the following fie
 > field would be absent on every one of them. A type whose fields are declared
 > so they can be queried must not then hide the field people query by.
 
-### 6.14 Compaction Rules
+### 6.15 Compaction Rules
 
 - Serializers MUST replace full field names with short keys before encoding
 - Deserializers MUST replace short keys with full field names after decoding
@@ -3545,8 +3545,8 @@ reclamation as unconditional.
 
 ### 28.4.4 Subject reachability (new in 1.6)
 
-CAL §8.14 defines the erasure selector (`FORGET SUBJECT "<id>"`) and §8.14 its
-read-only mirror (`REPORT SUBJECT`), and prior revisions said what those
+CAL §8.14 defines the erasure selector (`FORGET SUBJECT "<id>"`) and CAL §8.19
+its read-only mirror (`REPORT SUBJECT`), and prior revisions said what those
 statements *mean* without ever saying what they must **reach**. That gap is not
 academic. It was found in a conforming implementation as a silent
 under-erasure:

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -3651,6 +3651,14 @@ Conversations are reconstructed from Event grain sequences using `session_id` an
 1. Query: `type=event, session_id=X, system_valid_to=null, sort=timestamp_ms ASC`
 2. Or: start from the most recent Event grain (`messages_tail` in a State grain) and follow `parent_message_id` backward.
 
+**Mail and other addressed transports.** A mail thread is a conversation under
+this convention, not a separate structure: the thread is the `session_id`, and
+the reply edge is `parent_message_id`. The transport's own identifiers
+(`Message-ID`, `In-Reply-To`, `References`) and its addressing (`From`, `To`,
+`Cc`, `Subject`) have no home among the Event fields, which model LLM turns —
+they belong to the `mail:` domain profile (Appendix A.8), which maps them onto
+this convention rather than beside it.
+
 ### 28.7 Session Handoff Convention
 
 When Agent A transfers control of a conversation to Agent B, the handoff is recorded using a Goal grain with `mg:delegates_to` relation and delegation scope fields (§6.11):
@@ -3911,6 +3919,73 @@ Applies to grains produced in consumer-facing agent contexts — personal assist
 | `con:ccpa_opted_out` | boolean | no | User has exercised CCPA opt-out of sale; MUST NOT be used as a processing basis — use `processing_basis` field instead |
 
 **Normative:** Grains with `"profile:consumer"` that include `user_id` or any direct identifier MUST set `processing_basis` to a lawful basis under GDPR Art. 6 / CCPA § 1798.100 before cross-system transfer. Grains with `con:ccpa_opted_out: true` MUST NOT be included in data sale or data broker transfers.
+
+### A.8 Mail Profile (`mail:`) (new in 1.6)
+
+**Tag:** `"profile:mail"` | **Namespace prefix:** `mail:`
+
+Applies to grains recording messages carried by an addressed, threaded
+transport — email (RFC 5322), and by extension any transport with the same
+shape. Mail profile fields are stored in the grain's `context` map (compact
+key: `ctx`), following the same pattern as other domain profiles.
+
+**Why a profile and not new common fields.** Event grains model LLM turns:
+`role` is a chat enum, and threading is `session_id` + `parent_message_id`
+(§28.6). Nothing anywhere in this specification names a sender, a recipient, a
+subject line, or an RFC 5322 `Message-ID`. Every mail-shaped agent therefore
+invents its own `context` keys, which defeats portability for exactly the
+grains most worth porting — an inbox is the archetypal thing an agent is asked
+to remember across tools. A profile fixes that at the vocabulary layer without
+touching the format: `context` already exists, domain profiles already
+replicate, and no compact key, content address, or grain type changes.
+
+The alternative considered and rejected was a first-class `thread_id` common
+field. It would have meant a new compact key on every grain type for a concept
+`session_id` already carries, in a format whose field map is normative and
+frozen (§6). Mapping onto the existing fields costs nothing and loses nothing.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `mail:message_id` | string | no | RFC 5322 `Message-ID`, angle brackets included, e.g. `"<CA+abc123@mail.example.com>"`. The transport's own identifier, distinct from the grain's content address |
+| `mail:in_reply_to` | string | no | RFC 5322 `In-Reply-To` — the `Message-ID` this message replies to |
+| `mail:references` | string[] | no | RFC 5322 `References` chain, oldest first |
+| `mail:from` | string | no | Envelope/header sender address |
+| `mail:to` | string[] | no | Primary recipient addresses |
+| `mail:cc` | string[] | no | Carbon-copy recipient addresses |
+| `mail:bcc` | string[] | no | Blind-copy addresses. Present only where the storing agent was the sender; MUST NOT be populated from a received message |
+| `mail:subject` | string | no | Header subject line |
+| `mail:date` | string | no | RFC 5322 `Date` header as an ISO 8601 string, distinct from `created_at` (when the grain was written) |
+| `mail:folder` | string | no | Mailbox or label the message was read from, e.g. `"INBOX"`, `"Receipts"` |
+| `mail:direction` | string | no | `"inbound"` \| `"outbound"` |
+| `mail:transport` | string | no | Transport family where not email, e.g. `"sms"`, `"whatsapp"`. Absent means email |
+
+**Mapping RFC 5322 onto Event fields (normative for the profile):**
+
+| RFC 5322 | OMS field | Note |
+|---|---|---|
+| Thread | `session_id` | The thread **is** the session. §28.6 already reconstructs a conversation from `session_id`; a mail thread is that conversation, so it MUST NOT get a parallel identifier |
+| `In-Reply-To` | `parent_message_id` **and** `mail:in_reply_to` | The two differ and both are needed: `parent_message_id` is the **content address** of the parent grain (resolvable in this memory), while `mail:in_reply_to` is the transport's `Message-ID` (resolvable at the transport, and the only form available when the parent has not been ingested) |
+| `Message-ID` | `mail:message_id` | Never the grain's content address. A resent or re-ingested message keeps its `Message-ID` while its grain address depends on the bytes stored |
+| `From` / `To` / `Cc` | `mail:from` / `mail:to` / `mail:cc` | Where an agent asserts facts *about* a correspondent, the identity also belongs in `subject`, so it is reachable by subject selection (§28.4.4) |
+| Body | `content` | With `role` set as for any Event |
+
+**Normative:**
+- A grain carrying `mail:` fields MUST declare `"profile:mail"` in
+  `structural_tags`.
+- `mail:message_id` MUST NOT be used as, or derived into, a content address.
+- Where a mail message is stored on behalf of an identifiable correspondent,
+  that correspondent SHOULD appear in `subject` — mail addresses are personal
+  data, and a correspondent reachable only through a `context` key is not
+  reachable by subject erasure or disclosure (§28.4.4, which reaches structured
+  references, not opaque body fields).
+- `mail:bcc` MUST NOT be populated from a received message: a recipient that
+  can see a blind-copy list has been handed a disclosure the sender did not
+  make.
+
+> **Status:** this profile is specified ahead of a reference implementation.
+> Unlike the rest of the 1.6 draft it was not written from working code, and
+> the field set should be read as a starting point for comment rather than as
+> settled vocabulary.
 
 ### A.7 Integration Profile (`int:`)
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1,8 +1,8 @@
 # Open Memory Specification (OMS)
 ## Memory Grain (.mg) Container Definition
 
-**Version:** 1.5
-**Status:** Standards Track
+**Version:** 1.6-draft
+**Status:** Draft for Comment (OMS 1.6 RFC) — changed sections are normative only upon release
 **Category:** Data Formats
 **Date:** August 2026
 **Copyright:** Public Domain (CC0 1.0 Universal)
@@ -787,8 +787,8 @@ The `mg:` namespace is reserved for standard semantic relations. Applications de
 | `mg:state_at` | State | Agent state snapshot |
 | `mg:has_graph` | Workflow | Directed graph of procedural steps |
 | `mg:intends` | Goal | Agent objective |
-| `mg:permits` | Consent | User grants agent right to retain or act |
-| `mg:revokes` | Consent | User revokes prior consent |
+| `mg:permits` | Consent, Fact | User grants agent right to retain or act (Consent); as a Fact in `agent:authz`, an authorization grant (§12.6.2) |
+| `mg:revokes` | Consent | User revokes prior consent (data-subject domain only — authorization revocation is retraction-by-supersession, §12.6.3) |
 | `mg:prohibits` | Fact/Goal | Hard prohibition |
 | `mg:requires` | Fact/Goal | Hard requirement |
 | `mg:prefers` | Fact | Soft preference |
@@ -1111,7 +1111,7 @@ Where a Reasoning grain (§8.8) records *why the agent believes something* and a
 - `summary` (map) — a deterministic, template-rendered description: `{template_id: string, args: map}`. An analyzer MUST NOT store free prose here; the human-readable string is produced by rendering `template_id` with `args`, so summaries stay reproducible and translatable.
 - `dedup_key` (string) — the recommendation's stable proposal identity, computed (never author-chosen) per normative rule 5. Two recommendations with the same `dedup_key` are the same proposal; a supersession chain (evidence refresh, a growing cluster) shares one `dedup_key` across all of its content addresses.
 - exactly one **proposal** field:
-  - `proposal_cal` (string) — a CAL batch of Tier-1 *evolve* writes (`ADD` / `SUPERSEDE` / `REVERT`; CAL §2.2). The standard change form. CAL has no destructive verb — `FORGET`, `DELETE` and their kin are excluded at the grammar level and are parse errors, not keywords (CAL §2.4) — so a `proposal_cal` is always non-destructive and always invertible. A destructive change, where a host supports one at all, MUST be proposed as `proposal_data` and executed outside CAL.
+  - `proposal_cal` (string) — a CAL batch of Tier-1 *evolve* writes (`ADD` / `SUPERSEDE` / `REVERT`; CAL §2.2), the standard change form, and — since CAL 1.3, where the host authorizes destructive proposals — Tier-2 destruction statements (`FORGET`; CAL §8.14). A Tier-1-only `proposal_cal` is always non-destructive and always invertible. A `proposal_cal` carrying Tier-2 statements executes only if the applying principal holds the required `delete`/`erase` verbs (§12.6; CAL §8.16.1 two-key property), and its apply MUST be recorded **not rollbackable** (§8.12.1). CAL's Tier-3 governance statements (`APPROVE`/`APPLY`/…) are refused inside `proposal_cal` unconditionally — a recommendation must not approve recommendations (CAL §8.14.3). Predicate destruction remains grammar-excluded at every tier (CAL §2.4). A destructive change beyond CAL's Tier-2 shapes MUST be proposed as `proposal_data` and executed outside CAL.
   - `proposal_edit` (map) — `{format: string, base_digest: string, diff: string}` for `doc:` targets; `base_digest` lets an applier detect a stale base before editing.
   - `proposal_data` (map) — an opaque host-config change for `host:` targets.
 - `created_at` (int64, epoch ms)
@@ -1133,7 +1133,7 @@ Where a Reasoning grain (§8.8) records *why the agent believes something* and a
 - **Authoritative record.** Each lifecycle transition is one immutable **audit Observation grain** (§8.6) hash-chained per recommendation: its `derived_from` includes the recommendation's content address and the previous audit grain's address (plus any result addresses). The acting principal is recorded in the audit grain's existing `observer_id` (§8.6) — e.g. `"user:alice"`, `"agent:worker-3"`, `"policy:auto"` — and its class in `observer_type`, which MUST be either `"human"` (registered, §24.2) or one of the namespaced values `"rec:agent"`, `"rec:policy"`, `"rec:system"` (§24.3). No field beyond the Observation schema is introduced. The transition's mandatory human-readable reason is carried in the audit grain's `object` (§6.1) — the common field CAL projects as an Observation's text content (CAL §10.3.2), so the reason renders correctly in SML with no additional rule (RECOMMENDED ≤ 500 chars). An audit grain's `observer_id` MUST NOT be elided under §10.2: the acting principal is what makes the chain tamper-evident, and a selectively-disclosed chain that has dropped it is no longer an audit trail. The chain is portable, tamper-evident, and fork-mergeable.
 - **State machine.** `pending → approved | rejected`; `approved → applied`; `applied → rolled_back`; and `rejected → pending`, which lets a recommendation re-enter review on refreshed evidence under its existing `dedup_key` rather than becoming a second proposal. `pending → applied` directly is permitted **only** when the transition's `observer_type` is `"rec:policy"` (auto-apply); `observer_type` — never `observer_id` — is the discriminator for this gate, since `observer_id` is a host-asserted label with no normative structure. `applied` and `rolled_back` are terminal. `expired` is computed from `valid_to` and is reachable only from `pending` or `approved`; an expired recommendation MUST NOT be applied, and expiry of an `approved` recommendation withdraws that approval.
 - **Content vs. lifecycle.** A change in the recommendation's *content* (refreshed evidence, a larger cluster) is a **supersession** of the grain — a new content address with the **same `dedup_key`** — not a status change. Lifecycle ≠ content. A supersession MUST reset the superseding grain's `rec_status` to `pending`: approval is granted to specific content and never carries forward to content no reviewer has seen.
-- **Reproducible undo.** The inverse of an applied proposal is derived at apply time and recorded on the applied audit grain as a store-operation plan (no new CAL syntax): a `SUPERSEDE` reinstates the prior content; an `ADD` is undone by superseding the added grain with `invalidation_type: "retraction"`, which closes its `system_valid_to` and removes it from the default recall path while the blob itself survives (§5.6, §28.3) — OMS defines no separate tombstone mechanism, and none is needed; a `REVERT` is undone by superseding back to the reverted head; a document edit supersedes back to the prior head. Because CAL is structurally non-destructive (§2.4 of the CAL spec), every `proposal_cal` is rollbackable. A `proposal_data` change is opaque to OMS and MAY be irreversible: a host that cannot derive an inverse for one MUST record it as not rollbackable on the applied audit grain rather than offer a rollback it cannot perform.
+- **Reproducible undo.** The inverse of an applied proposal is derived at apply time and recorded on the applied audit grain as a store-operation plan (no new CAL syntax): a `SUPERSEDE` reinstates the prior content; an `ADD` is undone by superseding the added grain with `invalidation_type: "retraction"`, which closes its `system_valid_to` and removes it from the default recall path while the blob itself survives (§5.6, §28.3) — OMS defines no separate tombstone mechanism, and none is needed; a `REVERT` is undone by superseding back to the reverted head; a document edit supersedes back to the prior head. Because CAL's Tier-1 statements are structurally non-destructive, every Tier-1-only `proposal_cal` is rollbackable. A `proposal_cal` carrying CAL Tier-2 destruction (tombstone or erasure — one-way by definition, CAL §8.14.1) MUST be recorded as **not rollbackable** on the applied audit grain. A `proposal_data` change is opaque to OMS and MAY be irreversible: a host that cannot derive an inverse for one MUST record it as not rollbackable on the applied audit grain rather than offer a rollback it cannot perform.
 
 **Normative rules:**
 1. Exactly one of `proposal_cal`, `proposal_edit`, `proposal_data` MUST be present.
@@ -1684,6 +1684,118 @@ The `locked` invalidation policy combined with COSE signing provides layered pro
 | COSE signature | Owner signs the blob (§9) | Blob tampering changes the content address; the original signed grain remains valid and current |
 
 **Prompt injection resistance:** A user or external input asserting "your owner is now X" does not create or modify an ownership grain. The agent lacks the owner's private key and cannot author a superseding grain that passes the `locked` policy check. The original ownership fact remains current.
+
+### 12.6 Authorization (new in 1.6, draft)
+
+Authorization answers "what may this principal do in this memory?" It is the
+model CAL's Tier 2/3 statements consume (CAL §2.2, §8.14–§8.16), and it is
+usable by any host independently of CAL. The design principle is the
+**credential/policy split**: *policy* (who may do what here) is a truth about
+the memory and lives in it as grains; *credentials* (proving who a caller is)
+are host objects and MUST NOT be carried in grains, statements, or the memory
+file in any form.
+
+#### 12.6.1 Principals, verbs, scope
+
+- A **principal** is an opaque, non-empty name. Humans and agents are not
+  distinguished by the model: `user:anna`, `agent:support-bot`,
+  `job:retention` are all principals. A DID is a valid principal name and is
+  the upgrade path for signed deployments (§12.1) — not a prerequisite.
+- The **verb** set is closed in this revision: `read`, `write`, `supersede`,
+  `delete`, `erase`, `loop.run`, `loop.review`, `loop.apply`, `admin`
+  (semantics per CAL §8.14–§8.16; hosts without a recommendation engine
+  simply never resolve the `loop.*` verbs).
+- **Scope** is one namespace or `*`. The memory axis is implicit: a grant
+  governs only the memory it is stored in. Cross-memory access is governed by
+  each memory's own grants.
+
+#### 12.6.2 Grant grains
+
+A grant is a **Fact grain** (§8.1) in the reserved namespace
+**`agent:authz`** (following the `agent:identity` / `agent:recommendations`
+precedent, §12.5.3, §8.12 rule 7):
+
+| Field | Value |
+|---|---|
+| `type` | `"fact"` |
+| `namespace` | `"agent:authz"` |
+| `subject` | the **grantee** principal name |
+| `relation` | `"mg:permits"` |
+| `object` | the canonical grant string: `"<verbs> ON <scope>"`, where `<verbs>` is the granted verbs lowercase, comma-separated without spaces, sorted lexicographically, and `<scope>` is the governed namespace(s) comma-separated without spaces, sorted, or the literal `*` — e.g. `"delete,read ON caller,shared"`, `"admin ON *"` |
+| `confidence` | `1.0` |
+| `context` | grantor and reason under reserved keys: `{"grantor": "<principal>", "because": "<reason>"}` (`because` present when given) |
+| `author_did` | RECOMMENDED where DIDs are deployed — binds the grant cryptographically when the grain is COSE-signed (§9) |
+
+The canonical `object` form is normative: two grants conferring the same
+rights MUST serialize to the same string, so grants deduplicate
+content-addressably and compare across implementations.
+
+**Effective rights** of a principal for a namespace = the union of the verbs
+in **live** grant grains naming it — grains in `agent:authz` with
+`subject = <principal>`, `relation = "mg:permits"`, not superseded
+(`superseded_by` unset, `system_valid_to` unset) — whose scope includes the
+namespace (or is `*`). Resolution MUST fail closed: an unknown principal or
+an empty result confers nothing.
+
+Because grants are ordinary grains, the PERMISSION relation category query
+(CAL §7) already retrieves them; CAL's `SHOW GRANTS` is sugar over it.
+
+#### 12.6.3 Revocation
+
+Revocation is **retraction-by-supersession** — the native invalidation
+mechanism (§5.6, §28.3), so grant history is append-only and auditable:
+
+- A **full revoke** supersedes the covering grant grain(s) with
+  `invalidation_type: "retraction"`, closing their `system_valid_to`.
+- A **partial revoke** supersedes the covering grant with a new grant grain
+  whose canonical `object` carries the reduced verb/scope set.
+- The revoking principal and reason ride the superseding grain's `context`
+  (`{"grantor": ..., "because": ...}`) and the standard invalidation fields.
+
+`mg:revokes` remains the **Consent-domain** relation for data-subject consent
+withdrawal (§8.10) — authorization revocation deliberately does not use it,
+so PERMISSION-category queries over live grains return exactly the effective
+grant set with no subtraction logic.
+
+**Authoring authority:** writing or superseding any grain in `agent:authz`
+requires the `admin` verb (or an owner session, §12.6.4). Every `erase`
+grant is explicit: if a future revision defines role bundles, no bundle may
+include `erase`.
+
+#### 12.6.4 Owner sessions and bootstrap
+
+A host MAY designate a local session as the memory's **owner** — the
+implicit superuser, exempt from grant lookup (the `root@localhost` /
+SQLite-file-owner precedent). The owner writes the first grant. A memory
+containing no grant grains confers nothing on any non-owner principal —
+fail-closed by construction — while remaining fully usable by its owner, so
+a single-operator memory never needs to know this section exists.
+
+**Tamper honesty:** whoever holds the file bytes is root over them — as with
+any database's data directory. Content addressing and the operation log make
+out-of-band edits *detectable*; COSE signing (§9) is the high-assurance
+upgrade path.
+
+#### 12.6.5 Replication
+
+Grant grains replicate as **sync**: an importer, follower, or hub applies
+them like any other grain, without re-authorization — the file carries its
+own access policy wherever it goes. *Authoring* a grant (creating or
+superseding in `agent:authz`) requires `admin`/owner authority at the
+writing host. Disclosure property: a synced memory reveals its principal
+names to every replica; deployments that consider principal names sensitive
+SHOULD use opaque identifiers.
+
+#### 12.6.6 Relationship to other mechanisms
+
+- `invalidation_policy` (§23) continues to govern *supersession of specific
+  grains*; §12.6 governs *operations by principals*. They compose: a
+  supersession must pass both.
+- Consent grains (§8.10) record *data-subject* consent and are unrelated to
+  operational authorization; do not encode grants as Consent.
+- The delegation fields (§6.11, `authorized_namespaces`) describe
+  *agent-to-agent* delegated authority in Goal grains; a host MAY map them
+  onto verbs, but grant grains are the authorization source of truth.
 
 ---
 
@@ -2955,6 +3067,7 @@ Examples:
 - `"acme:chatbot:agent-7"` — org-scoped, app-scoped, agent-scoped
 - `"acme:chatbot:agent-7:session-42"` — additionally run-scoped
 - `"agent:identity"` — reserved for ownership and identity grains (§12.5)
+- `"agent:authz"` — reserved for authorization grant grains (§12.6)
 - `"shared"` — default, no specific partition
 
 The `run_id` field (§6.1) provides session/run scoping orthogonal to the namespace hierarchy. Use `run_id` when runs are ephemeral and high-cardinality; use namespace segments when partitions are stable and low-cardinality.
@@ -2984,7 +3097,7 @@ OMS does not define a formal store API. However, implementations that expose a p
 | `exists` | `(content_address) → bool` | Check if a grain exists without retrieving it |
 | `query` | `(filters, sort, limit, cursor) → result_envelope` | Structured query with the response envelope from §28.1 |
 | `search` | `(embedding_or_text, filters, limit) → result_envelope` | Semantic similarity search combined with structured filters |
-| `delete` | `(content_address) → void \| error` | Compliance-only erasure (GDPR Art. 17, consent cascade). MUST NOT be exposed as a general-purpose API. MUST check litigation holds (`invalidation_policy.mode: "hold"`) before deleting. |
+| `delete` | `(content_address) → void \| error` | Compliance erasure (GDPR Art. 17, consent cascade, retention). MUST NOT be exposed as a general-purpose unauthenticated API; MAY be surfaced to authorized principals via CAL Tier 2 (`FORGET`/`PURGE`, CAL §8.14 — `delete`/`erase` verbs, §12.6), each execution writing an audit Observation. MUST check litigation holds (`invalidation_policy.mode: "hold"`) before deleting. **One-way:** additions roll back by retraction (supersession); a delete or erasure is final — no un-delete operation exists, and a host MUST NOT add one. |
 | `put_batch` | `(blob_bytes[]) → content_address[] \| error[]` | Batch ingest for consolidation, migration, and high-throughput scenarios |
 | `get_batch` | `(content_address[]) → grain[] \| not_found[]` | Batch retrieval for provenance chain traversal and context assembly |
 
@@ -3158,7 +3271,7 @@ CAL extends the store operations defined in §28.4 with a structured query langu
 | `supersede` | `SUPERSEDE <hash> SET field = value … REASON "…"` |
 | `query`/`search` + `get_batch` + compose | `ASSEMBLE … FROM … BUDGET <n> TOKENS` |
 | introspection | `DESCRIBE <type>` |
-| `delete` (compliance erasure) | no CAL equivalent — structurally excluded |
+| `delete` (compliance erasure) | `FORGET <hash>` / `FORGET SUBJECT` / `PURGE OLDER THAN` (Tier 2, authorization-gated, audited — CAL §8.14; no CAL equivalent on Tier-0/1 hosts) |
 
 **SML output format:**
 
@@ -3728,7 +3841,7 @@ footer        = 32OCTET  ; SHA-256 checksum
 |---------|------------|
 | Art. 5 (Data minimization) | `user_id` field enables per-person scope |
 | Art. 12-23 (Rights) | Structured data format for automated response |
-| Art. 17 (Erasure) | Crypto-erasure via key destruction |
+| Art. 17 (Erasure) | Crypto-erasure via key destruction; subject-scoped erasure expressible as CAL `FORGET SUBJECT` on Tier-2 hosts (§28.4, CAL §8.14) |
 | Art. 25 (Privacy by design) | Provenance and audit built-in |
 | Art. 30 (Records of processing) | `provenance_chain` and `created_at` timestamps support records-of-processing obligations |
 | Art. 32 (Security) | COSE signing, AES-256-GCM encryption |

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1130,7 +1130,7 @@ Where a Reasoning grain (§8.8) records *why the agent believes something* and a
 
 **Required fields:**
 - `type` = "recommendation"
-- `target_ref` (string) — the change target as `<scheme>:<opaque>`. Standard schemes: `grain:sha256:<hash>` (a specific grain), `entity:<namespace>/<subject>` (an entity), `query:<namespace>/<name>` (a saved query, CAL §8.18), `template:<namespace>/<name>` (a template, CAL §10.6), `doc:<host-id>` (a host document, e.g. `doc:claude.md`), `host:<opaque>` (an opaque host object). The scheme is the target-kind discriminator; the scheme set is open for host-defined targets.
+- `target_ref` (string) — the change target as `<scheme>:<opaque>`. Standard schemes: `grain:sha256:<hash>` (a specific grain), `entity:<namespace>/<subject>` (an entity), `query:<namespace>/<name>` (a saved query, CAL §8.18), `template:<namespace>/<name>` (a template, CAL §10.6) — either MAY be revision-qualified as `…@<definition_hash>` (§28.4.1) —, `doc:<host-id>` (a host document, e.g. `doc:claude.md`), `host:<opaque>` (an opaque host object). The scheme is the target-kind discriminator; the scheme set is open for host-defined targets.
 - `analyzer` (map) — the producing logic: `{id: string, params?: map}`, where `id` is a versioned identifier `publisher.name/major` (e.g. `"waiser.duplicate_sweep/1"`) and `params` is an optional snapshot of the parameters it ran with. Full "why" provenance without a second grain.
 - `summary` (map) — a deterministic, template-rendered description: `{template_id: string, args: map}`. An analyzer MUST NOT store free prose here; the human-readable string is produced by rendering `template_id` with `args`, so summaries stay reproducible and translatable.
 - `dedup_key` (string) — the recommendation's stable proposal identity, computed (never author-chosen) per normative rule 5. Two recommendations with the same `dedup_key` are the same proposal; a supersession chain (evidence refresh, a growing cluster) shares one `dedup_key` across all of its content addresses.
@@ -1157,13 +1157,13 @@ Where a Reasoning grain (§8.8) records *why the agent believes something* and a
 - **Authoritative record.** Each lifecycle transition is one immutable **audit Observation grain** (§8.6) hash-chained per recommendation: its `derived_from` includes the recommendation's content address and the previous audit grain's address (plus any result addresses). The acting principal is recorded in the audit grain's existing `observer_id` (§8.6) — e.g. `"user:alice"`, `"agent:worker-3"`, `"policy:auto"` — and its class in `observer_type`, which MUST be either `"human"` (registered, §24.2) or one of the namespaced values `"rec:agent"`, `"rec:policy"`, `"rec:system"` (§24.3). No field beyond the Observation schema is introduced. The transition's mandatory human-readable reason is carried in the audit grain's `object` (§6.1) — the common field CAL projects as an Observation's text content (CAL §10.3.2), so the reason renders correctly in SML with no additional rule (RECOMMENDED ≤ 500 chars). An audit grain's `observer_id` MUST NOT be elided under §10.2: the acting principal is what makes the chain tamper-evident, and a selectively-disclosed chain that has dropped it is no longer an audit trail. The chain is portable, tamper-evident, and fork-mergeable.
 - **State machine.** `pending → approved | rejected`; `approved → applied`; `applied → rolled_back`; and `rejected → pending`, which lets a recommendation re-enter review on refreshed evidence under its existing `dedup_key` rather than becoming a second proposal. `pending → applied` directly is permitted **only** when the transition's `observer_type` is `"rec:policy"` (auto-apply); `observer_type` — never `observer_id` — is the discriminator for this gate, since `observer_id` is a host-asserted label with no normative structure. `applied` and `rolled_back` are terminal. `expired` is computed from `valid_to` and is reachable only from `pending` or `approved`; an expired recommendation MUST NOT be applied, and expiry of an `approved` recommendation withdraws that approval.
 - **Content vs. lifecycle.** A change in the recommendation's *content* (refreshed evidence, a larger cluster) is a **supersession** of the grain — a new content address with the **same `dedup_key`** — not a status change. Lifecycle ≠ content. A supersession MUST reset the superseding grain's `rec_status` to `pending`: approval is granted to specific content and never carries forward to content no reviewer has seen.
-- **Reproducible undo.** The inverse of an applied proposal is derived at apply time and recorded on the applied audit grain as a store-operation plan (no new CAL syntax): a `SUPERSEDE` reinstates the prior content; an `ADD` is undone by superseding the added grain with `invalidation_type: "retraction"`, which closes its `system_valid_to` and removes it from the default recall path while the blob itself survives (§5.6, §28.3) — OMS defines no separate tombstone mechanism, and none is needed; a `REVERT` is undone by superseding back to the reverted head; a document edit supersedes back to the prior head. Because CAL's Tier-1 statements are structurally non-destructive, every Tier-1-only `proposal_cal` is rollbackable. A `proposal_cal` carrying CAL Tier-2 destruction (tombstone or erasure — one-way by definition, CAL §8.14.1) MUST be recorded as **not rollbackable** on the applied audit grain. A `proposal_data` change is opaque to OMS and MAY be irreversible: a host that cannot derive an inverse for one MUST record it as not rollbackable on the applied audit grain rather than offer a rollback it cannot perform.
+- **Reproducible undo.** The inverse of an applied proposal is derived at apply time and recorded on the applied audit grain as a store-operation plan (no new CAL syntax): a `SUPERSEDE` reinstates the prior content; an `ADD` is undone by superseding the added grain with `invalidation_type: "retraction"`, which closes its `system_valid_to` and removes it from the default recall path while the blob itself survives (§5.6, §28.3) — OMS defines no separate tombstone mechanism, and none is needed; a `REVERT` is undone by superseding back to the reverted head; a document edit supersedes back to the prior head; a **definition change** (§28.4.1) is undone by rewriting the replaced body recorded on the applied audit grain — which is why recording it is mandatory there, and why a definition target SHOULD be revision-qualified when proposed. Because CAL's Tier-1 statements are structurally non-destructive, every Tier-1-only `proposal_cal` is rollbackable. A `proposal_cal` carrying CAL Tier-2 destruction (tombstone or erasure — one-way by definition, CAL §8.14.1) MUST be recorded as **not rollbackable** on the applied audit grain. A `proposal_data` change is opaque to OMS and MAY be irreversible: a host that cannot derive an inverse for one MUST record it as not rollbackable on the applied audit grain rather than offer a rollback it cannot perform.
 
 **Normative rules:**
 1. Exactly one of `proposal_cal`, `proposal_edit`, `proposal_data` MUST be present.
 2. Recommendation grains MUST NOT be mutated in place; every content change is a supersession, every lifecycle transition an audit Observation grain (§8.6). The `rec_status` index-layer cache MUST be reconstructible from the audit chain alone.
 3. Lifecycle-derived state MUST NOT be writer-settable: `rec_status` is an index-layer field (§5.6, §6.1, §28.3), so the general rule that writers MUST NOT set index-layer fields applies to it, and a `SUPERSEDE … SET` targeting it MUST be rejected. Transitions occur only through the review/apply path that emits audit grains.
-4. `summary.template_id` MUST reference a deterministic template and `summary.args` MUST carry the values it interpolates; implementations MUST NOT store analyzer-authored free prose in `summary`.
+4. `summary.template_id` MUST reference a deterministic template and `summary.args` MUST carry the values it interpolates; implementations MUST NOT store analyzer-authored free prose in `summary`. Where the referenced template is a stored definition (§28.4.1), `template_id` SHOULD carry its revision as `<name>@<definition_hash>`: a template is editable host metadata, so a bare name renders a *summary* whose text can silently change after the reviewer approved it. A host that resolves a bare name MUST resolve it to the current revision and record which one it used on the audit grain.
 5. `dedup_key` MUST be computed (never author-chosen) as the lowercase hex SHA-256 of three NUL-separated, UTF-8 encoded components — **analyzer-family**, **`target_ref`**, **action-kind** — in exactly this order:
 
    ```
@@ -3385,6 +3385,30 @@ memory alongside its grains.
 | `anon:<namespace>` | A pseudonymized-egress policy | Yes — write-if-absent | §10.5.1 |
 | `vault:<namespace>:<placeholder>` | A sealed placeholder→value mapping | **Never, in either direction** | §10.5.2 |
 | `trg:<trigger>` | Per-host trigger evaluation state (baselines, cursors, dedup keys) | **No** — host-local by §27.8 | §27.8 |
+
+**Definition identity (normative).** A row under a *definition* prefix
+(`qry:`, `tpl:`) is a versionable object that other grains name and audit
+trails pin, so it MUST carry two distinct stamps, and an implementation MUST
+NOT collapse them:
+
+| Stamp | What it is | What it is for |
+|---|---|---|
+| `updated_at` | Epoch time the definition was last written | The replication tiebreaker (latest-wins) and the human-facing "when did this change" |
+| `definition_hash` | Lowercase hex SHA-256 over the NFC-normalized definition body, computed exactly as §5.2 computes a grain's content address over its canonical bytes | The stable identity of *this* revision |
+
+They answer different questions and neither substitutes for the other. A
+timestamp cannot identify a revision: two hosts that edit a template to the
+same body produce different `updated_at` values for identical content, and a
+latest-wins merge then picks a winner between two rows that do not actually
+differ. A hash cannot order revisions: it says *which* body, never *which
+came later*. Replication needs the ordering; an audit trail needs the identity.
+
+This closes the gap that made `template:<namespace>/<name>` and
+`query:<namespace>/<name>` unpinnable Recommendation targets (§8.12): a
+`target_ref` MAY carry the revision as `template:<namespace>/<name>@<definition_hash>`,
+and a Recommendation applied to a definition MUST record the **replaced body**
+on its applied audit grain, so the inverse it offers reinstates exactly the
+revision it displaced rather than "whatever was there before".
 
 Rows that record *usage* rather than definition — a last-execution stamp on a
 saved query, a last-evaluated stamp on a trigger — MUST NOT replicate even when

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -209,7 +209,8 @@ Hexadecimal values are lowercase. Byte sequences are represented in hex with spa
 | 0x0A | **Consent** | Permission grant or withdrawal — DID-scoped, purpose-bounded |
 | 0x0B | **Skill** | Packaged, reusable agent capability — definition (how-to, tools, resources) plus optional learned proficiency |
 | 0x0C | **Recommendation** | Governed, auditable proposal to change memory or agent configuration — reviewed, applied, and rollback-able |
-| 0x0D–0xEF | Reserved | Future standard types |
+| 0x0D | **Trigger** | Standing rule that starts a Workflow — an interval, a schedule, a source to poll, a condition to watch |
+| 0x0E–0xEF | Reserved | Future standard types |
 | 0xF0–0xFF | Domain profile types | Application-defined per Appendix A domain profiles |
 
 **Bytes 3-4 — Namespace Hash:** First two bytes of SHA-256(namespace), encoded as `uint16` big-endian. Provides 65,536 routing buckets without deserialization. Full namespace string remains authoritative in payload. This field is a routing hint only and MUST NOT be used for security decisions (see §13.3, §20).
@@ -503,7 +504,6 @@ To minimize blob size, human-readable field names are mapped to short keys befor
 
 | Full Name | Short Key | Type | Notes |
 |-----------|-----------|------|-------|
-| `trigger` | `trigger` | string | Activation condition |
 | `nodes` | `nodes` | array[string] | Graph node IDs/labels |
 | `edges` | `edges` | array[map] | Directed edges (see §8.4 edge schema) |
 | `bindings` | `bind` | map[string→string] | Node ID → Tool definition grain hash |
@@ -679,6 +679,34 @@ When a Goal or Fact grain uses the `mg:delegates_to` relation, the following fie
 | `metric_snapshot` | `msnap` | map |
 | `evidence_query` | `evq` | string |
 
+### 6.14 Trigger-Specific Fields
+
+| Full Name | Short Key | Type | Notes |
+|-----------|-----------|------|-------|
+| `kind` | `aknd` | string | Shared with Tool's `kind` — same field name, same short key; the type byte disambiguates the value space |
+| `workflow` | `twf` | string | Content address of the Workflow this trigger starts |
+| `connector` | `tcon` | string | |
+| `scope` | `tscp` | string | |
+| `enabled` | `tena` | bool | **Always emitted**, unlike most defaulted booleans — see below |
+| `dedup_key` | `tdk` | array[string] | |
+| `interval_secs` | `tint` | int | |
+| `cron` | `tcron` | string | |
+| `at_ms` | `tat` | int64 | |
+| `predicate` | `tpred` | map | Inner keys are the expression's own and are NOT compacted |
+| `members` | `tmem` | map[string→string] | Alias → trigger content address |
+| `correlate` | `tcorr` | string | |
+| `window_ms` | `twin` | int64 | |
+| `concurrency` | `tconc` | string | |
+| `catchup` | `tcatch` | string | |
+| `config` | `tcfg` | map | `int:` keys compact per §A.7; connector-specific keys stay verbatim |
+
+> **`enabled` is a deliberate exception to omit-when-default.** Omitting a
+> defaulted value exists to keep *pre-existing* blobs byte-identical across a
+> rollout, and a newly registered type has none. Omitting it would instead break
+> the most natural query over triggers — selecting the live ones — because the
+> field would be absent on every one of them. A type whose fields are declared
+> so they can be queried must not then hide the field people query by.
+
 ### 6.14 Compaction Rules
 
 - Serializers MUST replace full field names with short keys before encoding
@@ -849,7 +877,6 @@ Directed graph of procedural steps — plans, pipelines, and multi-path processe
 - `created_at` (int64, epoch ms)
 
 **Optional fields:**
-- `trigger` (string) — condition that activates this workflow
 - `edges` (array[map]) — directed edges between nodes (see edge schema below). When absent, nodes are unconnected.
 - `bindings` (map[string→string]) — maps node IDs to Tool definition grain hashes (`tool_phase: "definition"`). Unbound nodes are resolved by convention (tool name match) or treated as abstract steps.
 - `retries` (map[string→int]) — maps node IDs to maximum repeat count on failure. Absent means no retry.
@@ -894,7 +921,6 @@ Directed graph of procedural steps — plans, pipelines, and multi-path processe
 ```json
 {
   "type": "workflow",
-  "trigger": "merge to main",
   "nodes": ["build", "test", "deploy"],
   "edges": [
     {"src": "build", "dst": "test"},
@@ -909,7 +935,6 @@ Directed graph of procedural steps — plans, pipelines, and multi-path processe
 ```json
 {
   "type": "workflow",
-  "trigger": "PR opened",
   "nodes": ["lint", "security", "compliance", "evaluate"],
   "edges": [
     {"src": "lint", "dst": "security"},
@@ -926,7 +951,6 @@ Directed graph of procedural steps — plans, pipelines, and multi-path processe
 ```json
 {
   "type": "workflow",
-  "trigger": "release requested",
   "nodes": ["build", "unit_test", "lint", "integration_test", "stage_deploy", "approval", "prod_deploy", "rollback", "notify"],
   "edges": [
     {"src": "build", "dst": "unit_test"},
@@ -1153,6 +1177,121 @@ Where a Reasoning grain (§8.8) records *why the agent believes something* and a
 7. Recommendation grains SHOULD use a dedicated namespace (e.g. `"agent:recommendations"`) to keep the proposal queue efficiently discoverable and separable from user memory.
 8. **Execution authority.** A stored `proposal_cal` is CAL authored by one principal and executed later by another, so it does not carry a capability of its own — CAL binds every query to a `CapabilityToken` at execution time (CAL §2.3). An applier MUST execute the batch under the **approving principal's** capability, never the analyzer's and never an ambient store authority; for an auto-applied recommendation it is the host-configured policy principal for the recommendation's namespace, not a principal derived from `observer_id` — that field is a host-asserted label with no normative structure and MUST NOT be resolved to a capability. An applier MUST reject a proposal whose writes resolve outside the recommendation's own namespace: a recommendation MUST NOT propose writes into a namespace it does not itself inhabit.
 9. **Bounds and target validation.** `proposal_cal` MUST NOT exceed CAL's `MAX_QUERY_LENGTH` (8192 bytes), and applying it is subject to the same Tier-1 write quotas as any other CAL batch (CAL §2.3). Before applying a `proposal_edit`, a host MUST resolve the `doc:` target against an allowlist and MUST verify `base_digest` against the current document head, rejecting the proposal if the base has drifted. `proposal_data` is opaque to OMS: a host MUST validate it against its own schema before applying, and SHOULD require it to be signed (§9) when the recommendation crosses a trust boundary.
+
+### 8.13 Trigger (type = 0x0D)
+
+A standing rule that starts a Workflow — an interval, a calendar schedule, an
+external source to poll, a condition over this memory, or a gate over other
+triggers.
+
+**Required fields:**
+- `type` = "trigger"
+- `kind` (string) — see the kind registry below
+- `workflow` (string) — content address of the Workflow grain (§8.4) this
+  trigger starts
+- `created_at` (int64, epoch ms)
+
+**Optional fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `connector` | string | Name of the external system, e.g. `"gmail"`, `"stripe"`. Part of the firing identity (see §27.8) |
+| `scope` | string | What is watched, in the connector's own vocabulary, e.g. `"mailbox:accounts@example.com"` |
+| `enabled` | bool | Whether the trigger is live. Default `true` |
+| `dedup_key` | array[string] | JSON Pointers (RFC 6901) into an item, joined in order, identifying the *occurrence* |
+| `interval_secs` | int | Seconds between firings, for `interval` and `polling` |
+| `cron` | string | Calendar expression, for `schedule` |
+| `at_ms` | int64 | Absolute instant, for `once` |
+| `predicate` | map | A filter expression: selects grains for `memory`, composes members for `composite` |
+| `members` | map[string→string] | Alias → trigger content address, for `composite` |
+| `correlate` | string | JSON Pointer whose value correlates member firings |
+| `window_ms` | int64 | How long a partial `composite` match stays live |
+| `concurrency` | string | `"forbid"` (default) \| `"allow"` \| `"replace"` |
+| `catchup` | string | `"last"` (default) \| `"none"` \| `"all"` |
+| `config` | map | Connector transport configuration, using the `int:` keys of the Integration profile (§A.7) |
+| All common fields | | |
+
+**`kind` registry** (closed):
+
+| Value | Fires when |
+|---|---|
+| `"interval"` | `interval_secs` have elapsed since the last firing |
+| `"schedule"` | the `cron` expression matches |
+| `"once"` | `at_ms` passes; never again |
+| `"polling"` | a connector reports new items |
+| `"memory"` | grains matching `predicate` appear in this memory |
+| `"webhook"` | the host delivers a payload |
+| `"manual"` | an operator fires it |
+| `"composite"` | `predicate` over `members` is satisfied |
+
+**Normative rules:**
+
+1. **Binding direction.** A Trigger names its Workflow; a Workflow MUST NOT
+   carry a list of triggers. A Workflow is content-addressed, so a plan
+   accumulating trigger references would change address whenever one was added
+   or removed, invalidating every reference to it — including a run's record of
+   which plan it executed.
+2. **Coherence.** A declaration that cannot fire MUST be rejected at write
+   time, not stored: an `interval` or `polling` trigger without a positive
+   `interval_secs`, a `schedule` without `cron`, a `once` without `at_ms`, a
+   `memory` without `predicate`, a `composite` with fewer than two `members` or
+   no `predicate`, or any trigger whose `workflow` is empty. A trigger that can
+   never fire has no symptom other than silence, which is indistinguishable from
+   a source with nothing new.
+3. **Member aliases.** For `composite`, `members` maps an alias to a content
+   address and `predicate` references the **aliases**. A content address is not
+   a legal identifier in an expression grammar, and an alias survives a member
+   being re-declared at a new address.
+4. **`config` carries transport, not identity.** The `int:` keys describe how to
+   reach a connector. A field that determines *whether or when* a trigger fires
+   is a first-class field above, so that it is queryable: implementations index
+   declared fields, not the interior of a `context`-shaped map.
+5. **Evaluation state is not part of the grain.** Next-due time, cursor,
+   lease and failure count are host-local operational state. See §27.8.
+
+**Example — polling an external source:**
+
+```json
+{
+  "type": "trigger",
+  "kind": "polling",
+  "workflow": "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90",
+  "connector": "gmail",
+  "scope": "mailbox:accounts@example.com",
+  "enabled": true,
+  "interval_secs": 120,
+  "dedup_key": ["/message_id"],
+  "config": {
+    "int:cursor_field": "since",
+    "int:cursor_type": "timestamp",
+    "int:allowed_outbound_hosts": ["https://gmail.googleapis.com"]
+  },
+  "namespace": "accounting",
+  "created_at": 1740700000000
+}
+```
+
+**Example — a gate over two other triggers:**
+
+```json
+{
+  "type": "trigger",
+  "kind": "composite",
+  "workflow": "b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90a1",
+  "members": {
+    "invoice": "c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2",
+    "purchase_order": "d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3"
+  },
+  "predicate": {
+    "kind": "and",
+    "left": { "kind": "comparison", "field": "invoice", "comparator": "eq", "value": true },
+    "right": { "kind": "comparison", "field": "purchase_order", "comparator": "eq", "value": true }
+  },
+  "correlate": "/thread_id",
+  "window_ms": 600000,
+  "created_at": 1740700000000
+}
+```
 
 ---
 
@@ -2082,7 +2221,7 @@ Implementations MUST declare which level they support:
 - Deserialize version byte + canonical MessagePack payload
 - Compute and verify SHA-256 content addresses
 - Support field compaction (short keys → full names)
-- Support all twelve standard grain types (0x01–0x0C) per §8 schemas
+- Support all thirteen standard grain types (0x01–0x0D) per §8 schemas
 - Ignore unknown fields
 - Constant-time hash comparison
 
@@ -2118,6 +2257,29 @@ All Level 2 requirements, plus:
 - Crash recovery and reconciliation
 - Policy engine with compliance presets
 - SHOULD partition Observation grain storage by observer domain, inferred from `observer_type`. Physical observer types (see Section 24) SHOULD flow to time-series storage with raw-data retention policies. Cognitive observer types SHOULD flow to vector + relational storage with the same retrieval semantics as Fact grains. Implementations MUST NOT hard-code the domain partition list — treat `observer_type` as an open string and drive routing from configuration or namespace.
+
+### 17.4 Optional modules
+
+Orthogonal to Levels 1–3, some capabilities are optional **modules**: not every
+store performs them, and one that does not is not a lesser implementation.
+Implementing a module means implementing it whole. This mirrors CAL's tier
+modules (CAL §24) — **modules gate operations, not portability.** Interoperability
+rides the `.mg` file: any Level 1 reader can read a memory containing a module's
+grains.
+
+| Module | Requires |
+|---|---|
+| `triggers` | The full execution contract of §27.8, including its idempotency, non-replication and arbitration rules |
+
+An implementation declares its modules alongside its level:
+
+```json
+{ "oms_conformance": 3, "oms_modules": ["triggers"] }
+```
+
+An implementation that stores and replicates Trigger grains without evaluating
+them MUST NOT declare the module. Storing them is ordinary grain handling and
+needs no declaration; *acting* on them is what the contract governs.
 
 ---
 
@@ -2950,109 +3112,41 @@ Scientific and legal workflows cite external artifacts outside the OMS hash spac
 
 The `derived_from` field SHOULD accept both OMS content addresses and external citation objects.
 
-### 27.6 Trigger Definitions via Observation Grains
+### 27.6 Trigger Definitions via Observation Grains — **REMOVED in 1.6**
 
-Triggers observe external systems for changes (new events, incoming webhooks, scheduled intervals). This maps naturally to the Observation grain (type 0x06) — triggers are observers. No new grain type is required; existing Observation fields accommodate trigger definitions through the following convention.
+Superseded by the **Trigger grain type (§8.13)**.
 
-**Field mapping for triggers:**
+This section described a convention in which a trigger was an Observation grain
+with `observer_type: "trigger:*"` and its configuration in the `context` map
+under `int:` keys, on the reasoning that *"existing Observation fields
+accommodate trigger definitions"*. That premise proved false three ways, and the
+section is removed rather than deprecated: preserving text that instructs
+implementers to write non-conformant grains is worse than removing it.
 
-| Observation Field | Trigger Usage |
-|---|---|
-| `observer_id` | Connector name (e.g., `"github"`, `"stripe"`) |
-| `observer_type` | Trigger mechanism: `"trigger:polling"`, `"trigger:webhook"`, `"trigger:schedule"`, `"trigger:listener"` |
-| `observation_mode` | `"periodic"` (polling), `"continuous"` (webhook/listener), `"scheduled"` (cron) |
-| `observation_scope` | What is being watched (e.g., `"repos/{owner}/{repo}/issues"`) |
-| `context` | Trigger-specific configuration using `int:` prefixed fields from the Integration profile (§A.7) |
+1. **It was non-conformant against this specification's own closed enums.** It
+   placed `"periodic"` / `"continuous"` / `"scheduled"` in `observation_mode`,
+   which §25 declares **closed** over `passive | active | reflective |
+   real_time`, and a watch target such as `"repos/{owner}/{repo}/issues"` in
+   `observation_scope`, which §26 declares **closed** over the *temporal
+   breadth* values `point | interval | session | longitudinal`. Every example the
+   section carried would be rejected by a Level 2 implementation enforcing §25
+   and §26.
+2. **Configuration in `context` could not be queried.** `context` is not among
+   Observation's queryable fields, and field resolution is top-level; a filter on
+   an `int:` key inside it cannot be pushed down. Moving the keys to the top
+   level would make them queryable but places them outside `context`, which is
+   where §A.7 says `int:` fields live. The two requirements were mutually
+   exclusive.
+3. **A trigger is not an observation.** §24 partitions observers into Physical
+   ("measurements of the material world") and Cognitive ("observations of the
+   information space"). A standing rule is neither, and registering `trigger:*`
+   would have required inventing a third domain solely to make the
+   classification hold.
 
-Implementations MAY index Observation grains whose `observer_type` starts with `"trigger:"` to provide trigger catalog queries.
-
-**Example — Polling trigger:**
-
-```json
-{
-  "type": "observation",
-  "observer_id": "github",
-  "observer_type": "trigger:polling",
-  "observation_mode": "periodic",
-  "observation_scope": "repos/{owner}/{repo}/issues",
-  "structural_tags": ["profile:integration"],
-  "namespace": "axtion:connectors:github",
-  "context": {
-    "int:http_method": "GET",
-    "int:http_path": "/repos/{owner}/{repo}/issues",
-    "int:path_params": ["owner", "repo"],
-    "int:poll_interval_secs": 300,
-    "int:cursor_field": "since",
-    "int:cursor_type": "timestamp",
-    "int:connector": "github",
-    "int:config_schema": {
-      "type": "object",
-      "properties": {
-        "owner": {"type": "string"},
-        "repo": {"type": "string"},
-        "labels": {"type": "string"}
-      },
-      "required": ["owner", "repo"]
-    },
-    "int:event_schema": {
-      "type": "object",
-      "properties": {
-        "id": {"type": "integer"},
-        "title": {"type": "string"},
-        "state": {"type": "string"}
-      }
-    }
-  },
-  "created_at": 1740700000000
-}
-```
-
-**Example — Webhook trigger:**
-
-```json
-{
-  "type": "observation",
-  "observer_id": "stripe",
-  "observer_type": "trigger:webhook",
-  "observation_mode": "continuous",
-  "observation_scope": "payment_intent.succeeded",
-  "structural_tags": ["profile:integration"],
-  "namespace": "axtion:connectors:stripe",
-  "context": {
-    "int:webhook_path": "/webhooks/stripe/{token}",
-    "int:webhook_secret_header": "Stripe-Signature",
-    "int:connector": "stripe",
-    "int:event_schema": {
-      "type": "object",
-      "properties": {
-        "id": {"type": "string"},
-        "amount": {"type": "integer"},
-        "currency": {"type": "string"}
-      }
-    }
-  },
-  "created_at": 1740700000000
-}
-```
-
-**Example — Scheduled trigger:**
-
-```json
-{
-  "type": "observation",
-  "observer_id": "scheduler",
-  "observer_type": "trigger:schedule",
-  "observation_mode": "scheduled",
-  "observation_scope": "daily-report",
-  "structural_tags": ["profile:integration"],
-  "context": {
-    "int:cron_expression": "0 9 * * MON-FRI",
-    "int:timezone": "America/New_York",
-    "int:connector": "scheduler"
-  },
-  "created_at": 1740700000000
-}
-```
+Migration: a trigger Observation becomes a Trigger grain (§8.13). `observer_id`
+becomes `connector`, the `trigger:*` suffix becomes `kind`, the watch target
+becomes `scope`, and the cadence keys become first-class fields. `int:` keys
+that genuinely describe connector transport stay in `config`.
 
 ### 27.7 Consensus Grain Usage for Tool Definition Validation
 
@@ -3088,6 +3182,71 @@ When multiple independent sources produce or validate the same Tool definition g
   "created_at": 1740700000000
 }
 ```
+
+---
+
+### 27.8 Trigger Execution Contract
+
+§8.13 defines what a trigger *is*. This section defines what an implementation
+that evaluates one MUST do. Declaring the shape without the contract was the
+gap that made the removed §27.6 unimplementable in an interoperable way: nothing
+normative said what evaluates a declaration, what a firing produces, or what
+idempotency a twice-delivered item receives.
+
+An implementation that evaluates triggers declares the `triggers` module (§17.4).
+One that does not MAY store and replicate Trigger grains without acting on them;
+they are ordinary grains.
+
+**1. Firing MUST be journaled.** Each firing writes a record naming the trigger,
+what it produced, and what it skipped. A trigger that has never fired MUST be
+distinguishable from one that has fired and found nothing — otherwise a
+misconfigured trigger and an idle one look identical, and the misconfiguration
+has no symptom.
+
+**2. Ingestion MUST be idempotent on the declared `dedup_key`.** The same item
+seen twice — connector replay, overlapping cursors, two evaluators racing — MUST
+produce one unit of work and a recorded skip, never two. Implementations SHOULD
+derive the work identity from `(connector, dedup value)` rather than the dedup
+value alone; following CloudEvents, an `id` is unique only within a producer, so
+two connectors sharing an id space would otherwise collide.
+
+**3. First evaluation MUST NOT replay history.** A newly declared `polling`
+trigger records the source's current position and fires nothing. Without this,
+declaring a trigger over an established source starts work for its entire
+history.
+
+**4. An absent baseline means different things for different kinds.** A trigger
+with no recorded next-due time has never been evaluated. For a *relative*
+cadence (`interval`, `polling`) that means it is due now — there is nothing to
+wait out. For an *absolute* schedule (`schedule`, `once`) it does NOT: the
+trigger is due at the instant it names, and an implementation MUST NOT fire a
+`cron` of `0 9 * * *` merely because it was just declared. A `once` trigger MUST
+fire at most once; "no next instant" MUST be represented distinctly from "no
+baseline yet", or it re-fires indefinitely.
+
+**5. Evaluation state MUST NOT replicate.** Next-due time, source cursor, lease
+and failure count are host-local. Replicating them lets two hosts sharing a
+memory each defer to the other's watermark, and lets a memory restored into a
+different environment inherit a cursor and silently skip work it should have
+done. This is the mirror of §8.12's rule that *governance* state must replicate:
+a record of who did what has to travel with the file; a record of where one host
+had got to must not.
+
+**6. Concurrent evaluation MUST be arbitrated by the store.** Where several
+evaluators can reach one memory, claiming MUST be a conditional write, and an
+evaluator whose claim has expired MUST NOT be able to write behind whichever
+one succeeded it. Losing a claim is a normal outcome and MUST NOT be reported as
+an error.
+
+**7. Failure MUST back off.** A connector that fails repeatedly MUST have its
+next evaluation deferred, and the reason MUST be inspectable. An implementation
+MUST NOT retry a failing source at its declared cadence.
+
+**8. Calendar semantics MUST be stated, not assumed.** Implementations disagree
+about a `cron` occurrence falling in a daylight-saving gap — some skip it, some
+fire it immediately — and agree only on the repeated hour, where it fires once.
+An implementation MUST document which it does, and SHOULD refuse a timezone it
+would mishandle rather than fire at the wrong hour and be believed.
 
 ---
 
@@ -3508,7 +3667,7 @@ Applies to grains that represent REST API connectors, tool catalog entries, webh
 | `int:sunset_date` | string | no | ISO 8601 date when this action will be removed |
 | `int:content_type` | string | no | Request content type if non-default (e.g., `"application/x-www-form-urlencoded"`) |
 
-**Trigger-specific fields** (used in Observation grains with `observer_type` starting with `"trigger:"`; see §27.6):
+**Trigger-specific fields** (connector transport configuration on a Trigger grain's `config` map, §8.13):
 
 | Field | Type | Used By | Description |
 |---|---|---|---|
@@ -3521,6 +3680,7 @@ Applies to grains that represent REST API connectors, tool catalog entries, webh
 | `int:timezone` | string | schedule | IANA timezone (e.g., `"America/New_York"`) |
 | `int:config_schema` | map | all | JSON Schema for trigger configuration |
 | `int:event_schema` | map | all | JSON Schema for emitted events |
+| `int:allowed_outbound_hosts` | string[] | all | URL prefixes a connector may reach. Scheme, host and port all take part in the match; `*.example.com` covers subdomains but not the apex. An absent key is unrestricted; an empty array denies everything — the two are different statements. A bare `*` SHOULD be refused: it lets a declaration appear policed while permitting every destination |
 
 **Normative:**
 - Grains with `"profile:integration"` SHOULD include `int:connector` and `int:auth_type`.
@@ -3891,7 +4051,31 @@ footer        = 32OCTET  ; SHA-256 checksum
   "icron": "int:cron_expression",
   "itz": "int:timezone",
   "icfg": "int:config_schema",
-  "ievt": "int:event_schema"
+  "ievt": "int:event_schema",
+  "iaoh": "int:allowed_outbound_hosts"
+}
+```
+
+**Trigger-Specific Fields (§8.13):**
+
+```json
+{
+  "aknd": "kind",
+  "twf": "workflow",
+  "tcon": "connector",
+  "tscp": "scope",
+  "tena": "enabled",
+  "tdk": "dedup_key",
+  "tint": "interval_secs",
+  "tcron": "cron",
+  "tat": "at_ms",
+  "tpred": "predicate",
+  "tmem": "members",
+  "tcorr": "correlate",
+  "twin": "window_ms",
+  "tconc": "concurrency",
+  "tcatch": "catchup",
+  "tcfg": "config"
 }
 ```
 


### PR DESCRIPTION
**Status: draft RFC, open for comment.**

This branch is the OMS 1.6 / CAL 1.3 / SML 1.2 draft. It began as the authorization RFC below and has since taken four more batches, the last three answering [#12](https://github.com/openmemoryspec/oms/issues/12) — the consolidated catch-up ticket filed after building a production agent on the reference implementation.

| Batch | What | Answers |
|---|---|---|
| Authorization | Four tiers, Tier-2 destruction, Tier-3 control + governance | — |
| Anonymization | OMS §10.5 pseudonymized egress; CAL `WITH anonymize`, `REHYDRATE` | — |
| Trigger | §8.13 Trigger grain (`0x0D`), §27.8 execution contract, §17.4 modules; §27.6 and `Workflow.trigger` removed | #12 §4 |
| Saved query | CAL §8.18; OMS §28.4.1 host metadata table | #12 §1 |
| Template identity | Definition identity (`updated_at` + `definition_hash`); CAL §10.6.3 `DROP TEMPLATE` | #12 §2 |
| Blob lifecycle | §7.1.1 `cas:` scheme, `put_blob`/`get_blob`, §28.4.2 concurrency, §28.4.3 erasure | #12 §5 |
| Subject reachability | §28.4.4 + CAL §8.19 `REPORT SUBJECT` | #12 §6 |
| Mail profile | Appendix A.8 `mail:` | #12 §3 |
| Housekeeping | `mg:step_action` vocabulary, §14.3 disclosure axes, version markers | #12 §7 |

---

## The pillar change (the original RFC)

CAL 1.0–1.2 promised "non-destructive by grammar; no unsafe mode." The promise was true and had a hidden cost: real deployments still needed erasure — GDPR, retention — so destruction happened anyway, outside the language, ungoverned by any spec (the reference implementation's own documented deviation is the evidence). Exiling destruction never prevented it; it only prevented *specifying* it.

1.3 brings it inside, where grammar can bound its shape and grants can gate it per principal:

- **Four conformance tiers** — Core (read), Evolve (append-only), Destroy, Control. **Tiers gate operations, not portability**: interop rides the `.mg` file and Tier-0 reads, so a read-only implementation remains fully conformant forever.
- **Tier 2 — Destroy**: `FORGET <hash>`, `FORGET SUBJECT`, `PURGE OLDER THAN` — destruction takes a hash, an identity, or an age, never a predicate; one-way (no un-tombstone); every execution writes an audit Observation.
- **Tier 3 — Control**: `GRANT`/`REVOKE`/`SHOW GRANTS`/`DESCRIBE PRINCIPAL`. Grants live **in the memory** as `mg:permits` Facts (OMS §12.6); credentials stay host-side. Revocation is retraction-by-supersession — grant history is append-only.
- **Tier 3 — Governance**: `RUN LOOP`, `APPROVE`/`REJECT`/`APPLY`/`ROLLBACK` with BECAUSE as syntax; identity always derives from the host-bound session, never statement text.
- For any session without grants — and every Tier-0/1 implementation — CAL is exactly the language 1.0–1.2 promised.

## What the later batches add

**Triggers (#12 §4).** Went further than the issue asked, because §27.6's premise turned out to be false: it told implementers to write Observation grains carrying values its own closed enums (§25, §26) reject. Removed rather than deprecated — text instructing implementers to write invalid grains is worse than no text — and replaced with a real grain type plus §27.8's execution contract. `Workflow.trigger` is removed as breaking: a free-text activation condition no implementation evaluated.

**Saved queries (#12 §1).** Four places restricted saved-query bodies and OMS §8.12 made `query:<ns>/<name>` a Recommendation target, while no statement created one. Now defined, with the rule that earns its keep: **define-time validation MUST parse the body with parameters standing in**, because a stored query that cannot parse fails first for an unattended agent long after its author moved on. Defining is Tier 3; **running is Tier 0**, since collapsing them would make every consumer of a saved query an administrator.

This required OMS §28.4.1, the **host metadata table** — which §10.5.1, §10.5.2 and §27.8 had already been referring to as "reserved store-metadata prefixes" without this spec ever saying what such a row is.

**Definition identity (#12 §2).** Templates and saved queries carry `updated_at` *and* `definition_hash`, and neither substitutes for the other: a timestamp cannot identify a revision (two hosts editing to the same body get different stamps for identical content), and a hash cannot order revisions. Merge needs the order; the audit trail needs the identity.

**Blobs (#12 §5).** `cas:` is defined at last — address over *plaintext* bytes, so content addresses identically encrypted or not. Erasure now reaches attachments, and two of those rules exist because the obvious implementation is wrong: reclamation must be targeted rather than a store-wide sweep (a census sees content uploaded but not yet referenced as garbage, and collecting it destroys an unrelated caller's data), and the surviving-reference check must run under the erasure's own serialization.

**Subject reachability (#12 §6).** The compliance-grade one. The spec defined the erasure selector without saying what it must *reach*, and a conforming implementation under-erased silently: a grain with a `subject` but no relation or object reached no index, so the identity's own transcript survived an erasure **that reported success** and went undisclosed in a DSAR **that reported completeness**. Now normative, with a required conformance case, plus CAL §8.19 `REPORT SUBJECT` — which rule 3 ("erasure and disclosure MUST share one selector") is about, and which this spec had never defined though the implementation ships it.

## Two things reviewers should push back on

1. **`DROP` leaves CAL §2.4's exclusion list**, which said "This list is permanent: no future tier unblocks it." It is admitted by a closed two-target production (`DROP TEMPLATE`, `DROP QUERY`) that reaches no grain. §2.4 argues the permanence claim survives — what was permanent is the exclusion of unbounded destruction *of memory*, and the token was blocked as a proxy for that property. If that reads as rationalization rather than reasoning, say so; the alternative is to spell it `UNDEFINE`, which is already reserved.

2. **The `mail:` profile is the one batch written ahead of an implementation.** Everything else here was written from working code. The section says so, and its field set should be read as a starting point rather than settled vocabulary.

## Reference implementation

Areev has the full CAL 1.3 surface implemented and tested, including a cross-surface parity gate ("every governed operation has a CAL spelling") in CI. Every CAL example added in these batches parses against its actual parser.

One divergence is recorded in Appendix C rather than papered over: its registry assigned `CAL-E040`–`E059` to template and saved-query errors, overlapping the Evolve codes this registry published in 1.5 (only `CAL-E044` agrees). Codes are append-only on both sides, so the saved-query family takes a fresh `CAL-E130`–`E137` block and the overlap stays an implementation defect to reconcile.
